### PR TITLE
fix: use directed edges instead of bidirectional in reduction graph

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -97,8 +97,9 @@ Reduction graph nodes use variant IDs: `ProblemName[/GraphType][/Weighted]`
 - Test naming: `test_<source>_to_<target>_closed_loop`
 
 ### Paper (docs/paper/reductions.typ)
-- `problem-def(name, title, body)` — defines a problem with auto-generated schema, reductions list, and label `<def:ProblemName>`
-- `reduction-rule(source, target, ...)` — generates a theorem with label `<thm:Source-to-Target>` and registers in `covered-rules` state
+- `problem-def(name)[body]` — defines a problem with auto-generated schema, reductions list, and label `<def:ProblemName>`. Title comes from `display-name` dict.
+- `reduction-rule(source, target, example: bool, ...)[rule][proof]` — generates a theorem with label `<thm:Source-to-Target>` and registers in `covered-rules` state. Overhead auto-derived from JSON edge data.
+- Every directed reduction needs its own `reduction-rule` entry
 - Completeness warnings auto-check that all JSON graph nodes/edges are covered in the paper
 - `display-name` dict maps `ProblemName` to display text
 

--- a/.claude/rules/adding-models.md
+++ b/.claude/rules/adding-models.md
@@ -5,66 +5,23 @@ paths:
 
 # Adding a Model (Problem Type)
 
-## 1. Define the Model
-Create `src/models/<category>/<name>.rs`:
+**Reference implementation:** `src/models/graph/kcoloring.rs`
 
-```rust
-use serde::{Deserialize, Serialize};
-use crate::traits::Problem;
-use crate::types::{EnergyMode, ProblemSize, SolutionSize};
+## Steps
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MyProblem<G, W> {
-    graph: G,
-    weights: Vec<W>,
-}
+1. **Create** `src/models/<category>/<name>.rs` — follow the reference for struct definition, `Problem` impl, and optionally `ConstraintSatisfactionProblem` impl.
+2. **Register** in `src/models/<category>/mod.rs`.
+3. **Add tests** in `src/unit_tests/models/<category>/<name>.rs` (linked via `#[path]`).
+4. **Document** in `docs/paper/reductions.typ`: add `display-name` entry and `#problem-def("Name")[definition...]`.
 
-impl<G: Graph, W: NumericWeight> Problem for MyProblem<G, W> {
-    const NAME: &'static str = "MyProblem";
-    fn variant() -> Vec<(&'static str, &'static str)> {
-        vec![("graph", G::NAME), ("weight", W::NAME)]
-    }
-    type Size = W;
+## Categories
 
-    fn num_variables(&self) -> usize { self.graph.num_vertices() }
-    fn num_flavors(&self) -> usize { 2 }
-    fn problem_size(&self) -> ProblemSize { ProblemSize::new(vec![("num_vertices", ...)]) }
-    fn energy_mode(&self) -> EnergyMode { EnergyMode::LargerSizeIsBetter }
-    fn solution_size(&self, config: &[usize]) -> SolutionSize<Self::Size> {
-        // Compute objective value, check validity, return SolutionSize::new(value, is_valid)
-    }
-}
-```
+- `src/models/satisfiability/` — Satisfiability, KSatisfiability, CircuitSAT
+- `src/models/graph/` — MaximumIndependentSet, MinimumVertexCover, KColoring, etc.
+- `src/models/set/` — MinimumSetCovering, MaximumSetPacking
+- `src/models/optimization/` — SpinGlass, QUBO, ILP
+- `src/models/specialized/` — Factoring
 
-## 2. Register in Module
-Add to `src/models/<category>/mod.rs`:
-```rust
-mod my_problem;
-pub use my_problem::MyProblem;
-```
+## Naming
 
-## 3. Categories
-Place models in appropriate category:
-- `src/models/satisfiability/` - Satisfiability, KSatisfiability, CircuitSAT
-- `src/models/graph/` - MaximumIndependentSet, MinimumVertexCover, KColoring, etc.
-- `src/models/set/` - MinimumSetCovering, MaximumSetPacking
-- `src/models/optimization/` - SpinGlass, QUBO, ILP
-- `src/models/specialized/` - Factoring
-
-## 4. Required Traits
-- `Serialize`, `Deserialize` - JSON I/O support
-- `Clone`, `Debug` - Standard Rust traits
-- `Problem` - Core trait (see template above for required methods)
-- Consider `ConstraintSatisfactionProblem` if applicable (adds `constraints()`, `objectives()`, `weights()`)
-
-## 5. Naming
 Use explicit optimization prefixes: `Maximum` for maximization, `Minimum` for minimization (e.g., `MaximumIndependentSet`, `MinimumVertexCover`).
-
-## 6. Documentation
-- Add entry to `display-name` dict in `docs/paper/reductions.typ`
-- Add `#problem-def("ProblemName")[mathematical definition...]` in the paper
-
-## Anti-patterns
-- Don't create models without JSON serialization support
-- Don't forget to implement `solution_size()` with correct validity checks
-- Don't use concrete types when generic `W` and `G` are appropriate

--- a/.claude/rules/adding-reductions.md
+++ b/.claude/rules/adding-reductions.md
@@ -3,105 +3,45 @@ paths:
   - "src/rules/**/*.rs"
 ---
 
-# Adding a Reduction Rule (A → B)
+# Adding a Reduction Rule (A -> B)
 
-## 0. Brainstorm & Generate Test Data First
+**Reference implementation:** `src/rules/minimumvertexcover_maximumindependentset.rs`
+**Reference test:** `src/unit_tests/rules/minimumvertexcover_maximumindependentset.rs`
+**Reference example:** `examples/reduction_minimumvertexcover_to_maximumindependentset.rs`
+**Reference paper entry:** `docs/paper/reductions.typ` (search for `MinimumVertexCover` `MaximumIndependentSet`)
 
-Before writing any Rust code, follow this workflow:
+## 0. Before Writing Code
 
-1. **Brainstorm the reduction** — use `superpowers:brainstorming` to discuss with the user:
-   - Research the mathematical formulation (paper, textbook, or derive it)
-   - Understand the variable mapping and constraint encoding
-   - Discuss implementation approach: penalty values, matrix construction, solution extraction
-   - Read reference implementations in the codebase (e.g., `src/rules/spinglass_qubo.rs`) to understand conventions
-   - Agree on scope (weighted vs unweighted, specific graph types, const generics)
-   - Which example to demonstrate in the examples/ folder.
-2. **Generate ground truth test data** — use an existing library (e.g., Python with qubogen, qubovert, or networkx) to create small instances, reduce them, brute-force solve both sides, and export as JSON to `tests/data/<target>/`. It is recommended to download the relevant package and check the existing tests to understand how to construct tests. To generate the test data, you can use the following command:
-   ```bash
-   # Example: generate QUBO test data
-   cd scripts && uv run python generate_qubo_tests.py
-   ```
-3. **Write the implementation plan** — save to `docs/plans/` using `superpowers:writing-plans`. The plan must include implementation details from the brainstorming session (formulas, penalty terms, matrix construction, variable indexing).
+1. **Brainstorm** — use `superpowers:brainstorming` to discuss with the user:
+   - The math (variable mapping, constraint encoding, penalty terms)
+   - Which example instance to use in `examples/` (must be small, human-explainable, and agreed with the user)
+2. **Generate ground truth** — use Python scripts in `scripts/` (run with `uv`) to create test data in `tests/data/<target>/`.
+3. **Write plan** — save to `docs/plans/` using `superpowers:writing-plans`.
 
-## 1. Implementation
+## 1. Implement
 
-Create `src/rules/<source>_<target>.rs` following the pattern in `src/rules/spinglass_qubo.rs`:
+Create `src/rules/<source>_<target>.rs` following the reference. Key pieces:
+- `ReductionResult` struct + impl (`target_problem`, `extract_solution`, `source_size`, `target_size`)
+- `#[reduction(...)]` macro on `ReduceTo<Target> for Source` impl (auto-generates `inventory::submit!`)
+- `#[cfg(test)] #[path = ...]` linking to unit tests
 
-```rust
-use crate::reduction;
+Register in `src/rules/mod.rs`.
 
-#[derive(Debug, Clone)]
-pub struct ReductionSourceToTarget {
-    target: TargetProblem<...>,
-    source_size: ProblemSize,
-    // + any metadata needed for extract_solution
-}
+## 2. Test
 
-impl ReductionResult for ReductionSourceToTarget {
-    type Source = SourceProblem<...>;
-    type Target = TargetProblem<...>;
-
-    fn target_problem(&self) -> &Self::Target { &self.target }
-    fn extract_solution(&self, target_solution: &[usize]) -> Vec<usize> { ... }
-    fn source_size(&self) -> ProblemSize { self.source_size.clone() }
-    fn target_size(&self) -> ProblemSize { self.target.problem_size() }
-}
-
-#[reduction(
-    overhead = { ReductionOverhead::new(vec![...]) }
-)]
-impl ReduceTo<TargetProblem<...>> for SourceProblem<...> {
-    type Result = ReductionSourceToTarget;
-    fn reduce_to(&self) -> Self::Result { ... }
-}
-
-#[cfg(test)]
-#[path = "../unit_tests/rules/<source>_<target>.rs"]
-mod tests;
-```
-
-The `#[reduction]` macro auto-generates the `inventory::submit!` call. Optional attributes: `source_graph`, `target_graph`, `source_weighted`, `target_weighted`.
-
-Register module in `src/rules/mod.rs`:
-```rust
-mod source_target;
-pub use source_target::ReductionSourceToTarget;
-```
-
-## 2. Tests (Required)
-
-- **Unit tests** in `src/unit_tests/rules/<source>_<target>.rs` — closed-loop + edge cases. See `rules/testing.md`.
-- **Integration tests** in `tests/suites/reductions.rs` — compare against JSON ground truth from step 0.
-- Test name: `test_<source>_to_<target>_closed_loop`
+- **Unit tests** in `src/unit_tests/rules/<source>_<target>.rs` — closed-loop + edge cases (see reference test).
+- **Integration tests** in `tests/suites/reductions.rs` — compare against JSON ground truth.
 
 ## 3. Example Program
 
-Add a round-trip demo to `examples/` showing a practical, explainable instance:
-1. Create source problem
-2. Reduce to target, solve, extract solution
-3. Print human-readable explanation
-4. Dump the reduction information to a json file
+Add `examples/reduction_<source>_to_<target>.rs` — create, reduce, solve, extract, verify, export JSON (see reference example).
 
-## 4. Documentation
+## 4. Document
 
-Update `docs/paper/reductions.typ` (see `rules/documentation.md` for the pattern):
-- Add `reduction-rule("Source", "Target", ...)` theorem with proof sketch
-- Add Rust code example from the example program
-- Add `display-name` entry if the problem is new
+Update `docs/paper/reductions.typ` — add `reduction-rule("Source", "Target", ...)` with proof sketch (see `rules/documentation.md`).
 
-The goal is to 1. prove the correctness of the reduction to human beings. 2. provide a minimal working example to the readers.
+## 5. Regenerate Graph
 
-Citations must be verifiable. Use `[Folklore]` or `—` for trivial reductions.
-
-## 5. Regenerate Reduction Graph
 ```bash
 cargo run --example export_graph
 ```
-
-## Anti-patterns
-- Don't write Rust code before understanding the math and having test data
-- Don't create reductions without closed-loop tests
-- Don't forget `inventory::submit!` registration (reduction graph won't update)
-- Don't hardcode weights - use generic `W` parameter
-- Don't skip overhead polynomial specification
-- Don't skip the example program — every reduction needs an explainable demo

--- a/.claude/rules/adding-reductions.md
+++ b/.claude/rules/adding-reductions.md
@@ -15,13 +15,13 @@ Before writing any Rust code, follow this workflow:
    - Discuss implementation approach: penalty values, matrix construction, solution extraction
    - Read reference implementations in the codebase (e.g., `src/rules/spinglass_qubo.rs`) to understand conventions
    - Agree on scope (weighted vs unweighted, specific graph types, const generics)
+   - Which example to demonstrate in the examples/ folder.
 2. **Generate ground truth test data** — use an existing library (e.g., Python with qubogen, qubovert, or networkx) to create small instances, reduce them, brute-force solve both sides, and export as JSON to `tests/data/<target>/`. It is recommended to download the relevant package and check the existing tests to understand how to construct tests. To generate the test data, you can use the following command:
    ```bash
    # Example: generate QUBO test data
    cd scripts && uv run python generate_qubo_tests.py
    ```
-3. **Create a practical example** — design a small, explainable instance for `examples/` (e.g., "wireless tower placement" for MaximumIndependentSet, "map coloring" for KColoring). This example will also appear in the `docs/paper/reductions.typ`.
-4. **Write the implementation plan** — save to `docs/plans/` using `superpowers:writing-plans`. The plan must include implementation details from the brainstorming session (formulas, penalty terms, matrix construction, variable indexing).
+3. **Write the implementation plan** — save to `docs/plans/` using `superpowers:writing-plans`. The plan must include implementation details from the brainstorming session (formulas, penalty terms, matrix construction, variable indexing).
 
 ## 1. Implementation
 
@@ -77,9 +77,10 @@ pub use source_target::ReductionSourceToTarget;
 ## 3. Example Program
 
 Add a round-trip demo to `examples/` showing a practical, explainable instance:
-1. Create source problem with a real-world story
+1. Create source problem
 2. Reduce to target, solve, extract solution
 3. Print human-readable explanation
+4. Dump the reduction information to a json file
 
 ## 4. Documentation
 
@@ -94,7 +95,7 @@ Citations must be verifiable. Use `[Folklore]` or `—` for trivial reductions.
 
 ## 5. Regenerate Reduction Graph
 ```bash
-make export-graph
+cargo run --example export_graph
 ```
 
 ## Anti-patterns

--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -9,43 +9,53 @@ The technical paper (`docs/paper/reductions.typ`) must include:
 
 1. **Problem Definitions** — using `problem-def` wrapper
 2. **Reduction Theorems** — using `reduction-rule` function
-3. **Reduction Examples** — minimal working example showing reduce → solve → extract
+3. **Reduction Examples** — JSON data from `make examples`, rendered automatically
 
 ## Adding a Problem Definition
 
 ```typst
-#problem-def("MaximumIndependentSet", "Maximum Independent Set (MIS)")[
-  Mathematical definition...
+#problem-def("MaximumIndependentSet")[
+  Given $G = (V, E)$ with vertex weights $w: V -> RR$, find ...
 ]
 ```
 
 This auto-generates:
 - A label `<def:MaximumIndependentSet>` for cross-references
-- The problem's schema (fields from Rust struct)
-- The list of available reductions
+- The problem's schema (fields from JSON export)
+- The list of available reductions (from `reduction_graph.json` edges)
 
 Also add an entry to the `display-name` dictionary:
 ```typst
-"MaximumIndependentSet": "MIS",
+"MaximumIndependentSet": [Maximum Independent Set],
 ```
 
 ## Adding a Reduction Theorem
 
 ```typst
-#reduction-rule(
-  "MaximumIndependentSet", "QUBO",
-  example: "maximumindependentset_to_qubo",
-  overhead: (n: 0, m: 1),
+#reduction-rule("MaximumIndependentSet", "QUBO",
+  example: true,
+  example-caption: [IS on path $P_4$ to QUBO],
 )[
+  Rule statement...
+][
   Proof sketch...
 ]
 ```
+
+Parameters:
+- `source`, `target` — problem names (positional)
+- `example: bool` — if `true`, loads `examples/<source>_to_<target>.json` and `.result.json`
+- `example-caption: content` — caption for the example box
+- `extra: content` — additional content inside the example box
+- `theorem-body`, `proof-body` — the rule statement and proof (positional)
 
 This auto-generates:
 - A theorem label `<thm:MaximumIndependentSet-to-QUBO>`
 - References to source/target problem definitions (if they exist)
 - Registration in `covered-rules` state for completeness checking
-- The example code block from `examples/reduction_<example>.rs`
+- Overhead from `reduction_graph.json` edge data
+
+Every directed reduction in the graph needs its own `reduction-rule` entry.
 
 ## Completeness Warnings
 

--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -5,36 +5,27 @@ paths:
 
 # Documentation Requirements
 
-The technical paper (`docs/paper/reductions.typ`) must include:
-
-1. **Problem Definitions** — using `problem-def` wrapper
-2. **Reduction Theorems** — using `reduction-rule` function
-3. **Reduction Examples** — JSON data from `make examples`, rendered automatically
+**Reference:** search `docs/paper/reductions.typ` for `MinimumVertexCover` `MaximumIndependentSet` to see a complete problem-def + reduction-rule example.
 
 ## Adding a Problem Definition
 
 ```typst
-#problem-def("MaximumIndependentSet")[
-  Given $G = (V, E)$ with vertex weights $w: V -> RR$, find ...
+#problem-def("ProblemName")[
+  Mathematical definition...
 ]
 ```
 
-This auto-generates:
-- A label `<def:MaximumIndependentSet>` for cross-references
-- The problem's schema (fields from JSON export)
-- The list of available reductions (from `reduction_graph.json` edges)
-
-Also add an entry to the `display-name` dictionary:
+Also add to the `display-name` dictionary:
 ```typst
-"MaximumIndependentSet": [Maximum Independent Set],
+"ProblemName": [Problem Name],
 ```
 
 ## Adding a Reduction Theorem
 
 ```typst
-#reduction-rule("MaximumIndependentSet", "QUBO",
+#reduction-rule("Source", "Target",
   example: true,
-  example-caption: [IS on path $P_4$ to QUBO],
+  example-caption: [caption text],
 )[
   Rule statement...
 ][
@@ -42,23 +33,4 @@ Also add an entry to the `display-name` dictionary:
 ]
 ```
 
-Parameters:
-- `source`, `target` — problem names (positional)
-- `example: bool` — if `true`, loads `examples/<source>_to_<target>.json` and `.result.json`
-- `example-caption: content` — caption for the example box
-- `extra: content` — additional content inside the example box
-- `theorem-body`, `proof-body` — the rule statement and proof (positional)
-
-This auto-generates:
-- A theorem label `<thm:MaximumIndependentSet-to-QUBO>`
-- References to source/target problem definitions (if they exist)
-- Registration in `covered-rules` state for completeness checking
-- Overhead from `reduction_graph.json` edge data
-
-Every directed reduction in the graph needs its own `reduction-rule` entry.
-
-## Completeness Warnings
-
-The paper auto-checks completeness:
-- After Problem Definitions: warns if JSON graph nodes are missing from `display-name`
-- After Reductions section: warns if JSON graph edges are missing from `covered-rules`
+Every directed reduction in the graph needs its own `reduction-rule` entry. The paper auto-checks completeness against `reduction_graph.json`.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -4,9 +4,6 @@
 New code must have >95% test coverage.
 
 ```bash
-# Check coverage for specific module
-cargo tarpaulin --features ilp --skip-clean --ignore-tests -- <module_name>
-
 # Generate full HTML report
 make coverage
 ```
@@ -26,7 +23,7 @@ fn test_source_to_target_closed_loop() {
     let problem = SourceProblem::new(...);
 
     // 2. Reduce
-    let reduction = problem.reduce_to::<TargetProblem>();
+    let reduction = ReduceTo::<TargetProblem>::reduce_to(&problem);
     let target = reduction.target_problem();
 
     // 3. Solve target
@@ -36,7 +33,7 @@ fn test_source_to_target_closed_loop() {
     // 4. Extract and verify
     for sol in solutions {
         let extracted = reduction.extract_solution(&sol);
-        assert!(problem.is_valid_solution(&extracted));
+        assert!(problem.solution_size(&extracted).is_valid);
     }
 }
 ```

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,51 +1,18 @@
 # Testing Requirements
 
-## Coverage Requirement
-New code must have >95% test coverage.
+**Reference test:** `src/unit_tests/rules/minimumvertexcover_maximumindependentset.rs`
 
-```bash
-# Generate full HTML report
-make coverage
-```
+## Coverage
 
-## Test Naming Conventions
+New code must have >95% test coverage. Run `make coverage` to check.
+
+## Naming
+
 - Reduction tests: `test_<source>_to_<target>_closed_loop`
 - Model tests: `test_<model>_basic`, `test_<model>_serialization`
 - Solver tests: `test_<solver>_<problem>`
 
-## Closed-Loop Test Pattern
-Every reduction MUST have a closed-loop test:
-
-```rust
-#[test]
-fn test_source_to_target_closed_loop() {
-    // 1. Create small instance
-    let problem = SourceProblem::new(...);
-
-    // 2. Reduce
-    let reduction = ReduceTo::<TargetProblem>::reduce_to(&problem);
-    let target = reduction.target_problem();
-
-    // 3. Solve target
-    let solver = BruteForce::new();
-    let solutions = solver.find_best(target);
-
-    // 4. Extract and verify
-    for sol in solutions {
-        let extracted = reduction.extract_solution(&sol);
-        assert!(problem.solution_size(&extracted).is_valid);
-    }
-}
-```
-
-## Before Submitting PR
-```bash
-make test      # All tests pass
-make clippy    # No warnings
-make coverage  # >95% for new code
-```
-
-## Test File Organization
+## File Organization
 
 Unit tests live in `src/unit_tests/`, mirroring `src/` structure. Source files reference them via `#[path]`:
 
@@ -56,12 +23,10 @@ Unit tests live in `src/unit_tests/`, mirroring `src/` structure. Source files r
 mod tests;
 ```
 
-The `#[path]` is relative to the source file's directory. `use super::*` in the test file resolves to the parent module (same as inline tests).
+Integration tests are in `tests/suites/`, consolidated through `tests/main.rs`.
 
-Integration tests are consolidated into a single binary at `tests/main.rs`, with test modules in `tests/suites/`.
+## Before PR
 
-## Anti-patterns
-- Don't skip closed-loop tests for reductions
-- Don't test only happy paths - include edge cases
-- Don't ignore clippy warnings
-- Don't add inline `mod tests` blocks in `src/` — use `src/unit_tests/` with `#[path]`
+```bash
+make test clippy
+```

--- a/docs/paper/reduction_graph.json
+++ b/docs/paper/reduction_graph.json
@@ -315,7 +315,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_spins",
@@ -343,7 +342,6 @@
           "weight": "i32"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_gates",
@@ -367,7 +365,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -395,7 +392,6 @@
           "weight": "f64"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -420,7 +416,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -448,7 +443,6 @@
           "weight": "f64"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -456,6 +450,33 @@
         }
       ],
       "doc_path": "rules/coloring_qubo/index.html"
+    },
+    {
+      "source": {
+        "name": "KSatisfiability",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "target": {
+        "name": "Satisfiability",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "overhead": [
+        {
+          "field": "num_clauses",
+          "formula": "num_clauses"
+        },
+        {
+          "field": "num_vars",
+          "formula": "num_vars"
+        }
+      ],
+      "doc_path": "rules/sat_ksat/index.html"
     },
     {
       "source": {
@@ -472,7 +493,6 @@
           "weight": "f64"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -480,6 +500,87 @@
         }
       ],
       "doc_path": "rules/ksatisfiability_qubo/index.html"
+    },
+    {
+      "source": {
+        "name": "MaxCut",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "target": {
+        "name": "SpinGlass",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "overhead": [
+        {
+          "field": "num_spins",
+          "formula": "num_vertices"
+        },
+        {
+          "field": "num_interactions",
+          "formula": "num_edges"
+        }
+      ],
+      "doc_path": "rules/spinglass_maxcut/index.html"
+    },
+    {
+      "source": {
+        "name": "MaximumIndependentSet",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "target": {
+        "name": "MaximumSetPacking",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "overhead": [
+        {
+          "field": "num_sets",
+          "formula": "num_vertices"
+        },
+        {
+          "field": "num_elements",
+          "formula": "num_vertices"
+        }
+      ],
+      "doc_path": "rules/maximumindependentset_maximumsetpacking/index.html"
+    },
+    {
+      "source": {
+        "name": "MaximumIndependentSet",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "target": {
+        "name": "MinimumVertexCover",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "overhead": [
+        {
+          "field": "num_vertices",
+          "formula": "num_vertices"
+        },
+        {
+          "field": "num_edges",
+          "formula": "num_edges"
+        }
+      ],
+      "doc_path": "rules/minimumvertexcover_maximumindependentset/index.html"
     },
     {
       "source": {
@@ -496,7 +597,6 @@
           "weight": "f64"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -520,7 +620,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_sets",
@@ -548,7 +647,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": true,
       "overhead": [
         {
           "field": "num_vertices",
@@ -576,7 +674,6 @@
           "weight": "f64"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -600,7 +697,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": true,
       "overhead": [
         {
           "field": "num_vertices",
@@ -628,7 +724,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_sets",
@@ -656,7 +751,6 @@
           "weight": "f64"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -664,6 +758,29 @@
         }
       ],
       "doc_path": "rules/minimumvertexcover_qubo/index.html"
+    },
+    {
+      "source": {
+        "name": "QUBO",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "f64"
+        }
+      },
+      "target": {
+        "name": "SpinGlass",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "f64"
+        }
+      },
+      "overhead": [
+        {
+          "field": "num_spins",
+          "formula": "num_vars"
+        }
+      ],
+      "doc_path": "rules/spinglass_qubo/index.html"
     },
     {
       "source": {
@@ -680,7 +797,6 @@
           "weight": "i32"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vertices",
@@ -708,7 +824,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": true,
       "overhead": [
         {
           "field": "num_clauses",
@@ -736,7 +851,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vertices",
@@ -764,7 +878,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vertices",
@@ -792,7 +905,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": true,
       "overhead": [
         {
           "field": "num_vertices",
@@ -820,7 +932,6 @@
           "weight": "f64"
         }
       },
-      "bidirectional": true,
       "overhead": [
         {
           "field": "num_vars",

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -81,7 +81,7 @@ For theoretical background and correctness proofs, see the [PDF manual](https://
         problems[n.name].children.push(n);
       });
 
-      // Build edges at variant level
+      // Build edges at variant level, detecting bidirectional pairs
       var edgeMap = {};
       data.edges.forEach(function(e) {
         var srcId = variantId(e.source.name, e.source.variant);
@@ -90,7 +90,7 @@ For theoretical background and correctness proofs, see the [PDF manual](https://
         var rev = dstId + '->' + srcId;
         if (edgeMap[rev]) { edgeMap[rev].bidirectional = true; }
         else if (!edgeMap[fwd]) {
-          edgeMap[fwd] = { source: srcId, target: dstId, bidirectional: e.bidirectional || false, overhead: e.overhead || [], doc_path: e.doc_path || '' };
+          edgeMap[fwd] = { source: srcId, target: dstId, bidirectional: false, overhead: e.overhead || [], doc_path: e.doc_path || '' };
         }
       });
 

--- a/docs/src/reductions/reduction_graph.json
+++ b/docs/src/reductions/reduction_graph.json
@@ -315,7 +315,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_spins",
@@ -343,7 +342,6 @@
           "weight": "i32"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_gates",
@@ -367,7 +365,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -395,7 +392,6 @@
           "weight": "f64"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -420,7 +416,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -448,7 +443,6 @@
           "weight": "f64"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -456,6 +450,33 @@
         }
       ],
       "doc_path": "rules/coloring_qubo/index.html"
+    },
+    {
+      "source": {
+        "name": "KSatisfiability",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "target": {
+        "name": "Satisfiability",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "overhead": [
+        {
+          "field": "num_clauses",
+          "formula": "num_clauses"
+        },
+        {
+          "field": "num_vars",
+          "formula": "num_vars"
+        }
+      ],
+      "doc_path": "rules/sat_ksat/index.html"
     },
     {
       "source": {
@@ -472,7 +493,6 @@
           "weight": "f64"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -480,6 +500,87 @@
         }
       ],
       "doc_path": "rules/ksatisfiability_qubo/index.html"
+    },
+    {
+      "source": {
+        "name": "MaxCut",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "target": {
+        "name": "SpinGlass",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "overhead": [
+        {
+          "field": "num_spins",
+          "formula": "num_vertices"
+        },
+        {
+          "field": "num_interactions",
+          "formula": "num_edges"
+        }
+      ],
+      "doc_path": "rules/spinglass_maxcut/index.html"
+    },
+    {
+      "source": {
+        "name": "MaximumIndependentSet",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "target": {
+        "name": "MaximumSetPacking",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "overhead": [
+        {
+          "field": "num_sets",
+          "formula": "num_vertices"
+        },
+        {
+          "field": "num_elements",
+          "formula": "num_vertices"
+        }
+      ],
+      "doc_path": "rules/maximumindependentset_maximumsetpacking/index.html"
+    },
+    {
+      "source": {
+        "name": "MaximumIndependentSet",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "target": {
+        "name": "MinimumVertexCover",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "Unweighted"
+        }
+      },
+      "overhead": [
+        {
+          "field": "num_vertices",
+          "formula": "num_vertices"
+        },
+        {
+          "field": "num_edges",
+          "formula": "num_edges"
+        }
+      ],
+      "doc_path": "rules/minimumvertexcover_maximumindependentset/index.html"
     },
     {
       "source": {
@@ -496,7 +597,6 @@
           "weight": "f64"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -520,7 +620,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_sets",
@@ -548,7 +647,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": true,
       "overhead": [
         {
           "field": "num_vertices",
@@ -576,7 +674,6 @@
           "weight": "f64"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -600,7 +697,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": true,
       "overhead": [
         {
           "field": "num_vertices",
@@ -628,7 +724,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_sets",
@@ -656,7 +751,6 @@
           "weight": "f64"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vars",
@@ -664,6 +758,29 @@
         }
       ],
       "doc_path": "rules/minimumvertexcover_qubo/index.html"
+    },
+    {
+      "source": {
+        "name": "QUBO",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "f64"
+        }
+      },
+      "target": {
+        "name": "SpinGlass",
+        "variant": {
+          "graph": "SimpleGraph",
+          "weight": "f64"
+        }
+      },
+      "overhead": [
+        {
+          "field": "num_spins",
+          "formula": "num_vars"
+        }
+      ],
+      "doc_path": "rules/spinglass_qubo/index.html"
     },
     {
       "source": {
@@ -680,7 +797,6 @@
           "weight": "i32"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vertices",
@@ -708,7 +824,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": true,
       "overhead": [
         {
           "field": "num_clauses",
@@ -736,7 +851,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vertices",
@@ -764,7 +878,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": false,
       "overhead": [
         {
           "field": "num_vertices",
@@ -792,7 +905,6 @@
           "weight": "Unweighted"
         }
       },
-      "bidirectional": true,
       "overhead": [
         {
           "field": "num_vertices",
@@ -820,7 +932,6 @@
           "weight": "f64"
         }
       },
-      "bidirectional": true,
       "overhead": [
         {
           "field": "num_vars",

--- a/src/unit_tests/rules/graph.rs
+++ b/src/unit_tests/rules/graph.rs
@@ -157,6 +157,9 @@ fn test_to_json_string() {
     assert!(json_string.contains("MaximumIndependentSet"));
     assert!(json_string.contains("\"category\""));
     assert!(json_string.contains("\"overhead\""));
+
+    // The legacy "bidirectional" field must not be present
+    assert!(!json_string.contains("\"bidirectional\""), "JSON should not contain the removed 'bidirectional' field");
 }
 
 #[test]

--- a/src/unit_tests/rules/graph.rs
+++ b/src/unit_tests/rules/graph.rs
@@ -135,14 +135,15 @@ fn test_to_json() {
     // Check edges
     assert!(json.edges.len() >= 10);
 
-    // Check that IS <-> VC is marked bidirectional
-    let is_vc_edge = json.edges.iter().find(|e| {
-        (e.source.name.contains("MaximumIndependentSet") && e.target.name.contains("MinimumVertexCover"))
-            || (e.source.name.contains("MinimumVertexCover")
-                && e.target.name.contains("MaximumIndependentSet"))
+    // Check that IS -> VC and VC -> IS both exist as separate directed edges
+    let is_to_vc = json.edges.iter().any(|e| {
+        e.source.name == "MaximumIndependentSet" && e.target.name == "MinimumVertexCover"
     });
-    assert!(is_vc_edge.is_some());
-    assert!(is_vc_edge.unwrap().bidirectional);
+    let vc_to_is = json.edges.iter().any(|e| {
+        e.source.name == "MinimumVertexCover" && e.target.name == "MaximumIndependentSet"
+    });
+    assert!(is_to_vc, "Should have IS -> VC edge");
+    assert!(vc_to_is, "Should have VC -> IS edge");
 }
 
 #[test]
@@ -155,7 +156,7 @@ fn test_to_json_string() {
     assert!(json_string.contains("\"edges\""));
     assert!(json_string.contains("MaximumIndependentSet"));
     assert!(json_string.contains("\"category\""));
-    assert!(json_string.contains("\"bidirectional\""));
+    assert!(json_string.contains("\"overhead\""));
 }
 
 #[test]
@@ -402,36 +403,35 @@ fn test_categorize_circuit_as_specialized() {
 }
 
 #[test]
-fn test_edge_bidirectionality_detection() {
+fn test_directed_edge_pairs() {
     let graph = ReductionGraph::new();
     let json = graph.to_json();
 
-    // Count bidirectional and unidirectional edges
-    let bidirectional_count = json.edges.iter().filter(|e| e.bidirectional).count();
-    let unidirectional_count = json.edges.iter().filter(|e| !e.bidirectional).count();
+    // IS <-> VC: both directions should exist as separate edges
+    let is_to_vc = json
+        .edges
+        .iter()
+        .any(|e| e.source.name == "MaximumIndependentSet" && e.target.name == "MinimumVertexCover");
+    let vc_to_is = json
+        .edges
+        .iter()
+        .any(|e| e.source.name == "MinimumVertexCover" && e.target.name == "MaximumIndependentSet");
+    assert!(is_to_vc, "Should have IS -> VC edge");
+    assert!(vc_to_is, "Should have VC -> IS edge");
 
-    // We should have both types
-    assert!(bidirectional_count > 0, "Should have bidirectional edges");
-    assert!(unidirectional_count > 0, "Should have unidirectional edges");
-
-    // Verify specific known bidirectional edges
-    let is_vc_bidir = json.edges.iter().any(|e| {
-        (e.source.name.contains("MaximumIndependentSet") && e.target.name.contains("MinimumVertexCover")
-            || e.source.name.contains("MinimumVertexCover")
-                && e.target.name.contains("MaximumIndependentSet"))
-            && e.bidirectional
-    });
-    assert!(is_vc_bidir, "IS <-> VC should be bidirectional");
-
-    // Verify specific known unidirectional edge
-    let factoring_circuit_unidir = json.edges.iter().any(|e| {
-        e.source.name.contains("Factoring")
-            && e.target.name.contains("CircuitSAT")
-            && !e.bidirectional
-    });
+    // Factoring -> CircuitSAT: only forward direction
+    let factoring_to_circuit = json
+        .edges
+        .iter()
+        .any(|e| e.source.name == "Factoring" && e.target.name == "CircuitSAT");
+    let circuit_to_factoring = json
+        .edges
+        .iter()
+        .any(|e| e.source.name == "CircuitSAT" && e.target.name == "Factoring");
+    assert!(factoring_to_circuit, "Should have Factoring -> CircuitSAT");
     assert!(
-        factoring_circuit_unidir,
-        "Factoring -> CircuitSAT should be unidirectional"
+        !circuit_to_factoring,
+        "Should NOT have CircuitSAT -> Factoring"
     );
 }
 


### PR DESCRIPTION
## Summary
- Remove the `bidirectional` flag from `EdgeJson` — each reversible reduction now emits two separate directed edges
- Fixes non-deterministic JSON export (inventory iteration order determined which direction was stored, breaking CI)
- Add 5 `reduction-rule` entries in the paper for the newly-explicit reverse directions (IS↔VC, IS↔SetPacking, SAT↔kSAT, SG↔MaxCut, SG↔QUBO)
- Update mdBook visualization JS to detect bidirectional pairs from two directed edges
- Update tests to match new schema (no `bidirectional` field)

## Test plan
- [x] `make test` — all 1551 tests pass
- [x] `make clippy` — no warnings
- [x] `typst compile docs/paper/reductions.typ` — compiles without errors
- [x] JSON export is deterministic (verified by diffing two runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)