### PR TITLE
feat(core): introduce v1 contract layer with legacy adapters

### DIFF
--- a/docs/architecture/v1-contract.md
+++ b/docs/architecture/v1-contract.md
@@ -1,0 +1,78 @@
+# v1 Core Contract
+
+**Status:** Draft  
+**Date:** 2026-02-11  
+**Scope:** Stable conceptual interfaces for problem definitions and reductions
+
+## Purpose
+
+This document defines the v1 contract for core concepts used across the crate:
+- Problem identity and variant metadata
+- Problem instance evaluation
+- Assignment representation
+- Reduction interface between problem instances
+
+The goal is to keep these concepts stable while implementation details evolve.
+
+## Core Types
+
+1. `Assignment`
+- Typed wrapper around `Vec<usize>`
+- Provides validation against `(num_variables, num_flavors)`
+
+2. `Evaluation<T>`
+- Stores `(objective, feasible)`
+- Replaces ad hoc raw tuples and aligns with legacy `SolutionSize<T>`
+
+3. `ObjectiveValue`
+- Semantic bound alias for objective numeric types
+- Centralizes repeated generic constraints
+
+4. `ObjectiveDirection`
+- `Maximize | Minimize`
+- Canonical comparison semantics (`is_better`, `is_better_or_equal`)
+
+5. `VariantDimension`
+- Typed key/value metadata replacing stringly variant pairs
+- Supports compatibility mapping from legacy `("graph", "SimpleGraph")` format
+
+## Core Traits
+
+1. `ProblemSpec`
+- `NAME`
+- `Value` (objective value type)
+- `variant_dimensions()`
+
+2. `ProblemInstance`
+- `num_variables()`
+- `num_flavors()`
+- `size_profile()`
+- `objective_direction()`
+- `evaluate_assignment()`
+
+3. `Reduction<S, T>`
+- `target_instance()`
+- `project_assignment()`
+- `source_size_profile()`
+- `target_size_profile()`
+
+## Compatibility Layer
+
+The v1 core currently coexists with legacy APIs:
+- `LegacyProblemAdapter<P>` wraps old `Problem` implementations.
+- `LegacyReductionAdapter<R, S, T>` wraps old `ReductionResult` implementations.
+
+This keeps the crate functional during migration while enabling incremental adoption of v1 interfaces.
+
+## Contract Invariants
+
+1. Assignment validation must detect both shape and flavor-range errors.
+2. Objective-direction comparison semantics must be deterministic and match legacy energy mode behavior.
+3. Reduction projection must map target assignments back into source assignment space.
+4. Variant metadata must remain serializable and stable for registry/export usage.
+
+## Next Steps
+
+1. Migrate registry/macro metadata to typed variant dimensions.
+2. Unify graph taxonomy under one canonical topology system.
+3. Incrementally migrate model and rule implementations to native v1 traits.

--- a/docs/plans/2026-02-11-types-interfaces-redesign-design.md
+++ b/docs/plans/2026-02-11-types-interfaces-redesign-design.md
@@ -1,0 +1,468 @@
+# Types and Interfaces Redesign (v1 Contract) - Full Implementation Plan
+
+**Date:** 2026-02-11  
+**Status:** Draft for alignment  
+**Decision Context:** Full redesign, spec-first, with priorities:
+- Internal architecture purity
+- Long-term API stability
+
+---
+
+## 1. Problem Statement
+
+The current crate works functionally, but contributor cognitive load is higher than necessary because core concepts are spread across overlapping abstractions and repeated implementation patterns:
+- Graph concepts are split across two systems (`src/topology` runtime graph trait and `src/graph_types` marker hierarchy).
+- Variant identity is stringly typed (`Vec<(&'static str, &'static str)>`) and repeated manually.
+- Numeric and objective bounds are repeated in many model impls instead of centralized semantic aliases.
+- Contributor docs and architecture docs are partially out of sync with actual trait shapes, which increases onboarding friction.
+- Reduction metadata registration, variant keys, and runtime path discovery depend on conventions that are not codified in one stable contract.
+
+This plan defines a **new v1 concept contract** first, then migrates implementation to match that contract while preserving predictable, durable API surfaces.
+
+---
+
+## 2. Goals and Non-Goals
+
+### Goals
+
+1. Define a single canonical conceptual model for problems, variants, assignments, evaluation, and reductions.
+2. Replace duplicated and stringly-typed interfaces with typed primitives and semantic bounds.
+3. Unify graph type taxonomy and runtime graph interface into one coherent model.
+4. Publish a stable v1 API boundary that contributors can learn once and reuse.
+5. Reduce boilerplate for new model/reduction implementation by at least 30% (measured by repeated trait-bound and variant code removal in representative models).
+6. Align code, docs, and contributor templates with one source of truth.
+
+### Non-Goals
+
+1. Adding new reduction algorithms.
+2. Optimizing solver performance beyond interface-driven refactors.
+3. Preserving old API names in perpetuity (this is a redesign; compatibility shims are temporary and explicitly time-bounded).
+
+---
+
+## 3. Approaches Considered
+
+### A. Spec-first (Chosen)
+
+Define and freeze a new v1 contract first, then migrate internals and implementations to it.
+
+Pros:
+- Strongest API stability outcome.
+- Internal refactors stay accountable to a fixed conceptual target.
+- Cleaner contributor docs and templates from day one of migration.
+
+Cons:
+- Requires upfront design and contract test scaffolding.
+- Initial velocity lower before migration starts.
+
+### B. Refactor-first
+
+Clean internals first, finalize API contract later.
+
+Pros:
+- Faster early code movement.
+
+Cons:
+- High risk of API drift during migration.
+- Docs and contributor guidance stay unstable longer.
+
+### C. Parallel API + internals iteration
+
+Evolve contract and internals simultaneously.
+
+Pros:
+- Potentially shorter elapsed time.
+
+Cons:
+- Hardest to reason about stability.
+- Highest review complexity and rework risk.
+
+**Recommendation:** A (Spec-first), already aligned with project decisions.
+
+---
+
+## 4. v1 Contract (Frozen Before Migration)
+
+### 4.1 Core Concepts
+
+1. `ProblemSpec`: static identity and variant dimensions.
+2. `ProblemInstance`: runtime instance data and evaluation behavior.
+3. `Assignment`: typed wrapper for decision vectors.
+4. `Evaluation<T>`: objective value + feasibility.
+5. `Reduction<S, T>`: transform + extraction mapping.
+6. `ObjectiveValue`: semantic alias for objective numeric bounds.
+
+### 4.2 Contract Sketch (Target Public Surface)
+
+```rust
+pub trait ObjectiveValue:
+    Clone + PartialOrd + num_traits::Num + num_traits::Zero + std::ops::AddAssign + 'static {}
+
+pub struct Assignment {
+    values: Vec<usize>,
+}
+
+pub struct Evaluation<T> {
+    pub objective: T,
+    pub feasible: bool,
+}
+
+pub enum ObjectiveSense {
+    Maximize,
+    Minimize,
+}
+
+pub enum VariantKey {
+    Graph,
+    Weight,
+    ConstParam(&'static str),
+    Domain(&'static str),
+}
+
+pub struct VariantDimension {
+    pub key: VariantKey,
+    pub value: &'static str,
+}
+
+pub trait ProblemSpec {
+    const NAME: &'static str;
+    type Value: ObjectiveValue;
+    fn objective_sense() -> ObjectiveSense;
+    fn variant() -> &'static [VariantDimension];
+}
+
+pub trait ProblemInstance: Clone + ProblemSpec {
+    fn num_variables(&self) -> usize;
+    fn num_flavors(&self) -> usize;
+    fn size_profile(&self) -> ProblemSize;
+    fn evaluate(&self, assignment: &Assignment) -> Evaluation<Self::Value>;
+}
+
+pub trait Reduction<S: ProblemInstance, T: ProblemInstance>: Clone {
+    fn target(&self) -> &T;
+    fn project_solution(&self, target_solution: &Assignment) -> Assignment;
+    fn source_size(&self) -> ProblemSize;
+    fn target_size(&self) -> ProblemSize;
+}
+```
+
+Note: exact names may differ, but concept roles and boundaries are frozen in Phase 0.
+
+### 4.3 Graph Model Unification
+
+Unify `src/topology/*` and `src/graph_types.rs` into:
+- A single runtime graph trait (`topology::Graph` stays canonical).
+- A typed graph taxonomy (`GraphKind`, subtype registry) colocated under `topology` and used by variant metadata + reduction applicability.
+
+Remove duplicate marker-only graph hierarchy once adapters are no longer needed.
+
+### 4.4 Registry and Macro Contract
+
+`#[reduction]` macro output must target typed v1 variant metadata and stable registry records. Registry data should be normalized around:
+- source spec id
+- target spec id
+- typed variant dimensions
+- overhead polynomial metadata
+- module path
+
+---
+
+## 5. Execution Plan (Phased)
+
+## Phase 0 - Freeze Contract and Guardrails
+
+### Deliverables
+
+1. v1 contract RFC in repo docs.
+2. Contract tests that assert semantics independent of specific problems.
+3. Migration tracking checklist.
+
+### File Targets
+
+- `docs/plans/2026-02-11-types-interfaces-redesign-design.md` (this file)
+- New: `docs/architecture/v1-contract.md`
+- New: `src/unit_tests/contracts/*`
+
+### Exit Criteria
+
+1. Contract reviewed and approved.
+2. No migration coding starts before contract tests compile.
+
+---
+
+## Phase 1 - Introduce v1 Core Modules (Additive)
+
+### Deliverables
+
+1. New core module layout:
+- `src/core/objective.rs`
+- `src/core/assignment.rs`
+- `src/core/evaluation.rs`
+- `src/core/variant.rs`
+- `src/core/problem.rs`
+- `src/core/reduction.rs`
+2. Re-export strategy in `src/lib.rs` and `prelude`.
+
+### Work
+
+1. Implement v1 types and traits.
+2. Keep existing traits (`Problem`, `ReduceTo`, `ReductionResult`) operational through adapters.
+3. Add conversion helpers:
+- `impl From<Vec<usize>> for Assignment`
+- `Assignment::as_slice()`
+- mapping between `SolutionSize<T>` and `Evaluation<T>`
+
+### Exit Criteria
+
+1. Build passes with both old and new abstractions present.
+2. Contract tests pass for dummy test problems.
+
+---
+
+## Phase 2 - Typed Variant and Graph Taxonomy Migration
+
+### Deliverables
+
+1. Typed variant dimension model used in new APIs.
+2. Unified graph subtype registry integrated into topology.
+
+### Work
+
+1. Move graph subtype entries into `topology` namespace.
+2. Replace raw `("graph", "...")` string pairs in new interfaces with `VariantDimension`.
+3. Add normalization utilities to preserve current variant-id output for graph export.
+4. Adapt reduction graph applicability checks to use unified graph taxonomy.
+
+### Exit Criteria
+
+1. `ReductionGraph` behavior unchanged on existing test suite.
+2. JSON graph export remains schema-compatible unless explicitly versioned.
+
+---
+
+## Phase 3 - Macro and Registry Refactor
+
+### Deliverables
+
+1. `problemreductions-macros` emits v1-compatible registry records.
+2. Registry structs updated for typed variant dimensions.
+
+### Work
+
+1. Extend proc-macro parsing for explicit variant dimension overrides where needed.
+2. Keep fallback inference for graph/weight types but write into typed fields.
+3. Introduce registry version marker to support transitional readers.
+
+### Exit Criteria
+
+1. All existing `#[reduction]` impls compile without behavior regressions.
+2. Inventory registration tests pass with typed variant metadata.
+
+---
+
+## Phase 4 - Model Migration (Representative, then Bulk)
+
+### Deliverables
+
+1. Migrate representative models first:
+- `MaximumIndependentSet`
+- `MinimumVertexCover`
+- `QUBO`
+- `Satisfiability`
+2. Bulk migration for remaining models.
+
+### Work
+
+1. Replace repeated numeric bounds with `ObjectiveValue`.
+2. Replace `solution_size(&[usize])` internals with assignment-based evaluation.
+3. Standardize constructor naming and accessor patterns where inconsistent.
+4. Remove per-model ad hoc variant string construction in favor of shared helpers.
+
+### Exit Criteria
+
+1. Representative model migration merged with no external behavior change.
+2. Full model set migrated and old trait impls available through adapters only.
+
+---
+
+## Phase 5 - Reduction and Solver API Migration
+
+### Deliverables
+
+1. New reduction interface wired through all rules.
+2. Solver trait supports assignment/evaluation primitives natively.
+
+### Work
+
+1. Update `src/rules/traits.rs` and rule implementations to v1 concepts.
+2. Add solver overloads:
+- `find_best_assignment`
+- compatibility wrappers for old methods.
+3. Ensure extraction and closed-loop reduction tests run on assignment wrappers.
+
+### Exit Criteria
+
+1. All rule unit tests pass.
+2. End-to-end examples still compile and produce equivalent outputs.
+
+---
+
+## Phase 6 - Documentation and Contributor UX Overhaul
+
+### Deliverables
+
+1. Rewrite architecture and contributor docs to match v1 exactly.
+2. Add model/reduction templates with new interfaces.
+
+### Work
+
+1. Update:
+- `docs/src/arch.md`
+- `docs/src/claude.md`
+- `.claude/rules/adding-models.md`
+- `.claude/rules/adding-reductions.md`
+2. Add “minimal contributor path” docs:
+- Implementing a new model in under N files.
+- Implementing a new reduction with template + checklist.
+3. Add lint/check script to detect docs drift against trait signatures.
+
+### Exit Criteria
+
+1. New contributor workflow tested by implementing one toy model and one toy reduction from templates.
+2. No stale references to removed APIs in docs.
+
+---
+
+## Phase 7 - Compatibility Window, Deprecation, and Removal
+
+### Deliverables
+
+1. Explicit compatibility window (one release cycle).
+2. Removal plan and changelog for old traits/interfaces.
+
+### Work
+
+1. Mark old traits/types deprecated with actionable migration messages.
+2. Provide migration guide with old-to-new mapping table.
+3. Remove deprecated layers at cutoff release.
+
+### Exit Criteria
+
+1. Migration guide complete and validated against all examples.
+2. Deprecated API removal branch passes full CI.
+
+---
+
+## 6. Data Flow (v1 Target)
+
+1. Instance creation:
+- User constructs `ProblemInstance`.
+2. Introspection:
+- `ProblemSpec` exposes name + typed variant dimensions.
+3. Evaluation:
+- Solver builds `Assignment`, invokes `evaluate`, reads `Evaluation`.
+4. Reduction:
+- `Reduction<S,T>` exposes target instance and solution projection.
+5. Registry/graph:
+- Typed variant dimensions flow into reduction graph applicability and exports.
+
+This flow replaces ad hoc mixing of metadata strings, raw vectors, and separate graph marker systems.
+
+---
+
+## 7. Error Handling Strategy
+
+1. Introduce v1 error categories:
+- `InvalidAssignment`
+- `VariantMismatch`
+- `ReductionNotApplicable`
+- `SchemaVersionMismatch`
+2. Keep error payloads structured and contributor-friendly.
+3. Ensure conversion from legacy errors to v1 errors during migration window.
+4. Add explicit validation entry points so panics become typed errors in external-facing paths where feasible.
+
+---
+
+## 8. Testing Strategy
+
+## 8.1 Contract Tests
+
+1. `Assignment` length and flavor validation.
+2. Objective sense ordering semantics.
+3. Variant dimension stability and serialization.
+4. Reduction projection round-trip invariants.
+
+## 8.2 Migration Safety Tests
+
+1. Golden tests comparing old vs new evaluation for representative problems.
+2. Golden tests for reduction graph node/edge identity.
+3. Macro expansion tests for registry metadata.
+
+## 8.3 End-to-End Tests
+
+1. Existing example runs remain green.
+2. Exported graph/schema artifacts diff-only where versioned changes are intended.
+3. Solver outputs and objective values unchanged for current fixtures.
+
+---
+
+## 9. Work Breakdown and Milestones
+
+1. M1: Contract frozen + tests scaffolded.
+2. M2: Core v1 modules merged.
+3. M3: Typed variant + unified graph taxonomy merged.
+4. M4: Macro/registry migrated.
+5. M5: Models migrated.
+6. M6: Rules and solvers migrated.
+7. M7: Docs/templates fully aligned.
+8. M8: Deprecation cutoff and cleanup complete.
+
+Each milestone requires green `make test clippy doc` and targeted artifact checks (`export-graph`, `export-schemas`).
+
+---
+
+## 10. Risk Register and Mitigations
+
+1. **Risk:** Graph taxonomy migration breaks reduction applicability.  
+   **Mitigation:** Keep compatibility adapter and run old/new applicability parity tests.
+
+2. **Risk:** Macro inference regressions for generic reductions.  
+   **Mitigation:** Add fixture-based macro expansion tests across representative reduction signatures.
+
+3. **Risk:** Contributor confusion during transition window.  
+   **Mitigation:** Keep one canonical v1 docs path and clearly label legacy docs as deprecated.
+
+4. **Risk:** Hidden reliance on string variant keys in downstream tooling.  
+   **Mitigation:** Keep stable serialized shape with explicit schema version and compatibility serializer.
+
+---
+
+## 11. Implementation Order Recommendation (PR Slices)
+
+1. PR1: v1 core types + contract tests (no model migration).
+2. PR2: typed variant + graph taxonomy unification + reduction graph parity tests.
+3. PR3: macro/registry migration.
+4. PR4: representative model migrations.
+5. PR5: bulk model + rule migrations.
+6. PR6: solver migration + compatibility shims.
+7. PR7: docs/templates overhaul.
+8. PR8: deprecation removals.
+
+This keeps review units coherent and allows rollback at milestone boundaries.
+
+---
+
+## 12. Success Criteria
+
+1. New contributors can implement a new model and reduction by following one v1 guide without reading legacy traits.
+2. Public v1 interfaces remain stable throughout migration after M1 freeze.
+3. Duplicate graph concept systems are removed.
+4. Boilerplate trait-bound duplication is materially reduced.
+5. All existing test suites and exports are green at completion.
+
+---
+
+## 13. Immediate Next Step (No Code Refactor Yet)
+
+Create and review `docs/architecture/v1-contract.md` as the normative contract artifact, then start PR1 with contract tests and additive core modules.
+

--- a/src/core/assignment.rs
+++ b/src/core/assignment.rs
@@ -1,0 +1,90 @@
+//! Assignment wrapper and validation helpers.
+
+use crate::error::{ProblemError, Result};
+use serde::{Deserialize, Serialize};
+
+/// A typed wrapper around variable assignments.
+///
+/// Each value must be in the range `0..num_flavors`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub struct Assignment {
+    values: Vec<usize>,
+}
+
+impl Assignment {
+    /// Create an assignment from raw values.
+    pub fn new(values: Vec<usize>) -> Self {
+        Self { values }
+    }
+
+    /// Create an assignment by cloning a slice.
+    pub fn from_slice(values: &[usize]) -> Self {
+        Self {
+            values: values.to_vec(),
+        }
+    }
+
+    /// Borrow raw assignment values.
+    pub fn as_slice(&self) -> &[usize] {
+        &self.values
+    }
+
+    /// Consume and return raw assignment values.
+    pub fn into_inner(self) -> Vec<usize> {
+        self.values
+    }
+
+    /// Number of variables in this assignment.
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Returns true if assignment is empty.
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// Validate assignment shape and flavor bounds.
+    pub fn validate(&self, num_variables: usize, num_flavors: usize) -> Result<()> {
+        if self.values.len() != num_variables {
+            return Err(ProblemError::InvalidConfigSize {
+                expected: num_variables,
+                got: self.values.len(),
+            });
+        }
+
+        for (idx, &value) in self.values.iter().enumerate() {
+            if value >= num_flavors {
+                return Err(ProblemError::InvalidFlavor {
+                    index: idx,
+                    value,
+                    num_flavors,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Fast boolean assignment validity check.
+    pub fn is_valid(&self, num_variables: usize, num_flavors: usize) -> bool {
+        self.validate(num_variables, num_flavors).is_ok()
+    }
+}
+
+impl From<Vec<usize>> for Assignment {
+    fn from(values: Vec<usize>) -> Self {
+        Self::new(values)
+    }
+}
+
+impl From<&[usize]> for Assignment {
+    fn from(values: &[usize]) -> Self {
+        Self::from_slice(values)
+    }
+}
+
+impl AsRef<[usize]> for Assignment {
+    fn as_ref(&self) -> &[usize] {
+        self.as_slice()
+    }
+}

--- a/src/core/evaluation.rs
+++ b/src/core/evaluation.rs
@@ -1,0 +1,81 @@
+//! Evaluation result for assignments.
+
+use crate::types::SolutionSize;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Objective evaluation paired with feasibility.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Evaluation<T> {
+    /// Objective value for this assignment.
+    pub objective: T,
+    /// Whether assignment satisfies hard constraints.
+    pub feasible: bool,
+}
+
+impl<T> Evaluation<T> {
+    /// Create a feasible evaluation.
+    pub fn feasible(objective: T) -> Self {
+        Self {
+            objective,
+            feasible: true,
+        }
+    }
+
+    /// Create an infeasible evaluation.
+    pub fn infeasible(objective: T) -> Self {
+        Self {
+            objective,
+            feasible: false,
+        }
+    }
+
+    /// Create evaluation with explicit feasibility.
+    pub fn new(objective: T, feasible: bool) -> Self {
+        Self {
+            objective,
+            feasible,
+        }
+    }
+
+    /// Transform objective type while preserving feasibility.
+    pub fn map<U, F>(self, mut f: F) -> Evaluation<U>
+    where
+        F: FnMut(T) -> U,
+    {
+        Evaluation {
+            objective: f(self.objective),
+            feasible: self.feasible,
+        }
+    }
+}
+
+impl<T> From<SolutionSize<T>> for Evaluation<T> {
+    fn from(value: SolutionSize<T>) -> Self {
+        Self {
+            objective: value.size,
+            feasible: value.is_valid,
+        }
+    }
+}
+
+impl<T> From<Evaluation<T>> for SolutionSize<T> {
+    fn from(value: Evaluation<T>) -> Self {
+        SolutionSize::new(value.objective, value.feasible)
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Evaluation<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Evaluation({}, {})",
+            self.objective,
+            if self.feasible {
+                "feasible"
+            } else {
+                "infeasible"
+            }
+        )
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,22 @@
+//! v1 core abstractions for problem definitions and reductions.
+//!
+//! This module introduces a typed, stable contract surface that can coexist
+//! with legacy traits during migration.
+
+pub mod assignment;
+pub mod evaluation;
+pub mod objective;
+pub mod problem;
+pub mod reduction;
+pub mod variant;
+
+pub use assignment::Assignment;
+pub use evaluation::Evaluation;
+pub use objective::{ObjectiveDirection, ObjectiveValue};
+pub use problem::{LegacyProblemAdapter, ProblemInstance, ProblemSpec};
+pub use reduction::{LegacyReductionAdapter, Reduction};
+pub use variant::{from_legacy_variant, VariantDimension, VariantKey};
+
+#[cfg(test)]
+#[path = "../unit_tests/contracts/mod.rs"]
+mod tests;

--- a/src/core/objective.rs
+++ b/src/core/objective.rs
@@ -1,0 +1,70 @@
+//! Objective value bounds and optimization direction.
+
+use crate::types::EnergyMode;
+use serde::{Deserialize, Serialize};
+
+/// Semantic bound for objective value types.
+pub trait ObjectiveValue:
+    Clone + PartialOrd + num_traits::Num + num_traits::Zero + std::ops::AddAssign + 'static
+{
+}
+
+impl<T> ObjectiveValue for T where
+    T: Clone + PartialOrd + num_traits::Num + num_traits::Zero + std::ops::AddAssign + 'static
+{
+}
+
+/// Objective optimization direction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ObjectiveDirection {
+    /// Larger objective values are better.
+    Maximize,
+    /// Smaller objective values are better.
+    Minimize,
+}
+
+impl ObjectiveDirection {
+    /// Returns true if this is a maximization objective.
+    pub fn is_maximization(&self) -> bool {
+        matches!(self, ObjectiveDirection::Maximize)
+    }
+
+    /// Returns true if this is a minimization objective.
+    pub fn is_minimization(&self) -> bool {
+        matches!(self, ObjectiveDirection::Minimize)
+    }
+
+    /// Compare two values according to objective direction.
+    pub fn is_better<T: PartialOrd>(&self, a: &T, b: &T) -> bool {
+        match self {
+            ObjectiveDirection::Maximize => a > b,
+            ObjectiveDirection::Minimize => a < b,
+        }
+    }
+
+    /// Compare two values according to objective direction.
+    pub fn is_better_or_equal<T: PartialOrd>(&self, a: &T, b: &T) -> bool {
+        match self {
+            ObjectiveDirection::Maximize => a >= b,
+            ObjectiveDirection::Minimize => a <= b,
+        }
+    }
+}
+
+impl From<EnergyMode> for ObjectiveDirection {
+    fn from(value: EnergyMode) -> Self {
+        match value {
+            EnergyMode::LargerSizeIsBetter => ObjectiveDirection::Maximize,
+            EnergyMode::SmallerSizeIsBetter => ObjectiveDirection::Minimize,
+        }
+    }
+}
+
+impl From<ObjectiveDirection> for EnergyMode {
+    fn from(value: ObjectiveDirection) -> Self {
+        match value {
+            ObjectiveDirection::Maximize => EnergyMode::LargerSizeIsBetter,
+            ObjectiveDirection::Minimize => EnergyMode::SmallerSizeIsBetter,
+        }
+    }
+}

--- a/src/core/problem.rs
+++ b/src/core/problem.rs
@@ -1,0 +1,109 @@
+//! v1 problem contracts and legacy adapter.
+
+use crate::core::assignment::Assignment;
+use crate::core::evaluation::Evaluation;
+use crate::core::objective::{ObjectiveDirection, ObjectiveValue};
+use crate::core::variant::{from_legacy_variant, VariantDimension};
+use crate::types::ProblemSize;
+
+/// Static problem identity and variant dimensions.
+pub trait ProblemSpec {
+    /// Stable base name for this problem.
+    const NAME: &'static str;
+
+    /// Objective value type for this problem.
+    type Value: ObjectiveValue;
+
+    /// Variant dimensions for this concrete type.
+    fn variant_dimensions() -> Vec<VariantDimension>;
+}
+
+/// Runtime problem instance behavior.
+pub trait ProblemInstance: Clone + ProblemSpec {
+    /// Number of decision variables.
+    fn num_variables(&self) -> usize;
+
+    /// Number of available flavors per variable.
+    fn num_flavors(&self) -> usize;
+
+    /// Size profile used by reduction overhead and complexity metadata.
+    fn size_profile(&self) -> ProblemSize;
+
+    /// Optimization direction for this instance.
+    fn objective_direction(&self) -> ObjectiveDirection;
+
+    /// Evaluate an assignment.
+    fn evaluate_assignment(&self, assignment: &Assignment) -> Evaluation<Self::Value>;
+
+    /// Evaluate raw assignment values.
+    fn evaluate_config(&self, config: &[usize]) -> Evaluation<Self::Value> {
+        self.evaluate_assignment(&Assignment::from_slice(config))
+    }
+
+    /// Validate assignment shape and flavor bounds.
+    fn validate_assignment(&self, assignment: &Assignment) -> crate::error::Result<()> {
+        assignment.validate(self.num_variables(), self.num_flavors())
+    }
+}
+
+/// Adapter that exposes a legacy `Problem` as a v1 `ProblemInstance`.
+#[derive(Debug, Clone)]
+pub struct LegacyProblemAdapter<P: crate::traits::Problem> {
+    inner: P,
+}
+
+impl<P: crate::traits::Problem> LegacyProblemAdapter<P> {
+    /// Wrap a legacy problem instance.
+    pub fn new(inner: P) -> Self {
+        Self { inner }
+    }
+
+    /// Borrow wrapped problem.
+    pub fn inner(&self) -> &P {
+        &self.inner
+    }
+
+    /// Consume adapter and return wrapped problem.
+    pub fn into_inner(self) -> P {
+        self.inner
+    }
+}
+
+impl<P> ProblemSpec for LegacyProblemAdapter<P>
+where
+    P: crate::traits::Problem,
+    P::Size: ObjectiveValue,
+{
+    const NAME: &'static str = P::NAME;
+    type Value = P::Size;
+
+    fn variant_dimensions() -> Vec<VariantDimension> {
+        from_legacy_variant(&P::variant())
+    }
+}
+
+impl<P> ProblemInstance for LegacyProblemAdapter<P>
+where
+    P: crate::traits::Problem,
+    P::Size: ObjectiveValue,
+{
+    fn num_variables(&self) -> usize {
+        self.inner.num_variables()
+    }
+
+    fn num_flavors(&self) -> usize {
+        self.inner.num_flavors()
+    }
+
+    fn size_profile(&self) -> ProblemSize {
+        self.inner.problem_size()
+    }
+
+    fn objective_direction(&self) -> ObjectiveDirection {
+        self.inner.energy_mode().into()
+    }
+
+    fn evaluate_assignment(&self, assignment: &Assignment) -> Evaluation<Self::Value> {
+        self.inner.solution_size(assignment.as_slice()).into()
+    }
+}

--- a/src/core/reduction.rs
+++ b/src/core/reduction.rs
@@ -1,0 +1,86 @@
+//! v1 reduction contract and legacy adapter.
+
+use crate::core::assignment::Assignment;
+use crate::core::problem::{LegacyProblemAdapter, ProblemInstance};
+use crate::types::ProblemSize;
+
+/// Reduction between source and target problem instances.
+pub trait Reduction<S: ProblemInstance, T: ProblemInstance>: Clone {
+    /// Borrow reduced target instance.
+    fn target_instance(&self) -> &T;
+
+    /// Project a target assignment back to source assignment space.
+    fn project_assignment(&self, target_solution: &Assignment) -> Assignment;
+
+    /// Source size profile at reduction time.
+    fn source_size_profile(&self) -> ProblemSize;
+
+    /// Target size profile at reduction time.
+    fn target_size_profile(&self) -> ProblemSize;
+}
+
+/// Adapter exposing a legacy `ReductionResult` as v1 `Reduction`.
+#[derive(Debug, Clone)]
+pub struct LegacyReductionAdapter<R, S, T>
+where
+    S: crate::traits::Problem,
+    T: crate::traits::Problem,
+    R: crate::rules::ReductionResult<Source = S, Target = T>,
+{
+    inner: R,
+    target: LegacyProblemAdapter<T>,
+    _marker: std::marker::PhantomData<S>,
+}
+
+impl<R, S, T> LegacyReductionAdapter<R, S, T>
+where
+    S: crate::traits::Problem,
+    T: crate::traits::Problem,
+    R: crate::rules::ReductionResult<Source = S, Target = T>,
+{
+    /// Wrap a legacy reduction result.
+    pub fn new(inner: R) -> Self {
+        let target = LegacyProblemAdapter::new(inner.target_problem().clone());
+        Self {
+            inner,
+            target,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Borrow wrapped legacy reduction.
+    pub fn inner(&self) -> &R {
+        &self.inner
+    }
+
+    /// Consume adapter and return wrapped legacy reduction.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+}
+
+impl<R, S, T> Reduction<LegacyProblemAdapter<S>, LegacyProblemAdapter<T>>
+    for LegacyReductionAdapter<R, S, T>
+where
+    S: crate::traits::Problem,
+    T: crate::traits::Problem,
+    S::Size: crate::core::objective::ObjectiveValue,
+    T::Size: crate::core::objective::ObjectiveValue,
+    R: crate::rules::ReductionResult<Source = S, Target = T>,
+{
+    fn target_instance(&self) -> &LegacyProblemAdapter<T> {
+        &self.target
+    }
+
+    fn project_assignment(&self, target_solution: &Assignment) -> Assignment {
+        Assignment::from(self.inner.extract_solution(target_solution.as_slice()))
+    }
+
+    fn source_size_profile(&self) -> ProblemSize {
+        self.inner.source_size()
+    }
+
+    fn target_size_profile(&self) -> ProblemSize {
+        self.inner.target_size()
+    }
+}

--- a/src/core/variant.rs
+++ b/src/core/variant.rs
@@ -1,0 +1,77 @@
+//! Typed variant dimensions for problem identity.
+
+use serde::{Deserialize, Serialize};
+
+/// Typed key for variant dimensions.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum VariantKey {
+    /// Graph topology type (e.g., `SimpleGraph`).
+    Graph,
+    /// Weight/objective value type (e.g., `i32`, `f64`).
+    Weight,
+    /// Const generic parameter key (e.g., `k`).
+    ConstParam(String),
+    /// Domain-specific dimension key.
+    Domain(String),
+    /// Arbitrary custom key for forward compatibility.
+    Custom(String),
+}
+
+impl VariantKey {
+    /// Legacy string key used by existing exports.
+    pub fn legacy_key(&self) -> &str {
+        match self {
+            VariantKey::Graph => "graph",
+            VariantKey::Weight => "weight",
+            VariantKey::ConstParam(key) => key.as_str(),
+            VariantKey::Domain(key) => key.as_str(),
+            VariantKey::Custom(key) => key.as_str(),
+        }
+    }
+
+    /// Build a typed key from a legacy string key.
+    pub fn from_legacy_key(key: &str) -> Self {
+        match key {
+            "graph" => VariantKey::Graph,
+            "weight" => VariantKey::Weight,
+            other => VariantKey::Custom(other.to_string()),
+        }
+    }
+}
+
+/// One typed variant dimension.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct VariantDimension {
+    /// Dimension key.
+    pub key: VariantKey,
+    /// Dimension value.
+    pub value: String,
+}
+
+impl VariantDimension {
+    /// Create a dimension with explicit key.
+    pub fn new(key: VariantKey, value: impl Into<String>) -> Self {
+        Self {
+            key,
+            value: value.into(),
+        }
+    }
+
+    /// Create a graph dimension.
+    pub fn graph(value: impl Into<String>) -> Self {
+        Self::new(VariantKey::Graph, value)
+    }
+
+    /// Create a weight dimension.
+    pub fn weight(value: impl Into<String>) -> Self {
+        Self::new(VariantKey::Weight, value)
+    }
+}
+
+/// Convert legacy variant pairs to typed dimensions.
+pub fn from_legacy_variant(legacy: &[(&str, &str)]) -> Vec<VariantDimension> {
+    legacy
+        .iter()
+        .map(|(k, v)| VariantDimension::new(VariantKey::from_legacy_key(k), *v))
+        .collect()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@
 //! - BMF: Boolean matrix factorization
 
 pub mod config;
+pub mod core;
 pub mod error;
 pub mod export;
 pub mod graph_types;
@@ -83,16 +84,20 @@ pub mod prelude {
     pub use crate::config::{
         bits_to_config, config_to_bits, config_to_index, index_to_config, ConfigIterator,
     };
+    pub use crate::core::{
+        Evaluation, ObjectiveDirection, ObjectiveValue, ProblemInstance, ProblemSpec, Reduction,
+        VariantDimension, VariantKey,
+    };
     pub use crate::error::{ProblemError, Result};
     pub use crate::models::graph::{
-        MaximumClique, MinimumDominatingSet, MaximumIndependentSet, KColoring, MaximumMatching, MaxCut, MaximalIS,
-        MinimumVertexCover,
+        KColoring, MaxCut, MaximalIS, MaximumClique, MaximumIndependentSet, MaximumMatching,
+        MinimumDominatingSet, MinimumVertexCover,
     };
     pub use crate::models::optimization::{
         Comparison, LinearConstraint, ObjectiveSense, SpinGlass, VarBounds, ILP, QUBO,
     };
     pub use crate::models::satisfiability::{CNFClause, KSatisfiability, Satisfiability};
-    pub use crate::models::set::{MinimumSetCovering, MaximumSetPacking};
+    pub use crate::models::set::{MaximumSetPacking, MinimumSetCovering};
     pub use crate::models::specialized::{BicliqueCover, CircuitSAT, Factoring, PaintShop, BMF};
     pub use crate::registry::{
         ComplexityClass, GraphSubcategory, ProblemCategory, ProblemInfo, ProblemMetadata,
@@ -106,6 +111,10 @@ pub mod prelude {
 }
 
 // Re-export commonly used items at crate root
+pub use core::{
+    Assignment, Evaluation, ObjectiveDirection, ObjectiveValue, ProblemInstance, ProblemSpec,
+    Reduction, VariantDimension, VariantKey,
+};
 pub use error::{ProblemError, Result};
 pub use registry::{ComplexityClass, ProblemCategory, ProblemInfo};
 pub use solvers::{BruteForce, Solver};

--- a/src/unit_tests/contracts/assignment.rs
+++ b/src/unit_tests/contracts/assignment.rs
@@ -1,0 +1,36 @@
+use crate::core::Assignment;
+use crate::error::ProblemError;
+
+#[test]
+fn test_assignment_validates_shape_and_flavors() {
+    let assignment = Assignment::from(vec![0, 1, 1, 0]);
+    assert!(assignment.validate(4, 2).is_ok());
+    assert!(assignment.is_valid(4, 2));
+}
+
+#[test]
+fn test_assignment_reports_invalid_size() {
+    let assignment = Assignment::from(vec![0, 1, 1]);
+    let err = assignment.validate(4, 2).unwrap_err();
+    assert_eq!(
+        err,
+        ProblemError::InvalidConfigSize {
+            expected: 4,
+            got: 3
+        }
+    );
+}
+
+#[test]
+fn test_assignment_reports_invalid_flavor() {
+    let assignment = Assignment::from(vec![0, 1, 2, 0]);
+    let err = assignment.validate(4, 2).unwrap_err();
+    assert_eq!(
+        err,
+        ProblemError::InvalidFlavor {
+            index: 2,
+            value: 2,
+            num_flavors: 2
+        }
+    );
+}

--- a/src/unit_tests/contracts/mod.rs
+++ b/src/unit_tests/contracts/mod.rs
@@ -1,0 +1,4 @@
+mod assignment;
+mod objective;
+mod reduction;
+mod variant;

--- a/src/unit_tests/contracts/objective.rs
+++ b/src/unit_tests/contracts/objective.rs
@@ -1,0 +1,31 @@
+use crate::core::ObjectiveDirection;
+use crate::types::EnergyMode;
+
+#[test]
+fn test_objective_direction_ordering() {
+    let max = ObjectiveDirection::Maximize;
+    let min = ObjectiveDirection::Minimize;
+
+    assert!(max.is_better(&10, &5));
+    assert!(!max.is_better(&5, &10));
+    assert!(min.is_better(&5, &10));
+    assert!(!min.is_better(&10, &5));
+
+    assert!(max.is_better_or_equal(&10, &10));
+    assert!(min.is_better_or_equal(&10, &10));
+}
+
+#[test]
+fn test_objective_direction_energy_mode_conversion() {
+    let max_mode: EnergyMode = ObjectiveDirection::Maximize.into();
+    let min_mode: EnergyMode = ObjectiveDirection::Minimize.into();
+
+    assert_eq!(
+        ObjectiveDirection::from(max_mode),
+        ObjectiveDirection::Maximize
+    );
+    assert_eq!(
+        ObjectiveDirection::from(min_mode),
+        ObjectiveDirection::Minimize
+    );
+}

--- a/src/unit_tests/contracts/reduction.rs
+++ b/src/unit_tests/contracts/reduction.rs
@@ -1,0 +1,152 @@
+use crate::core::{
+    Assignment, Evaluation, LegacyProblemAdapter, LegacyReductionAdapter, ObjectiveDirection,
+    ProblemInstance, ProblemSpec, Reduction, VariantDimension,
+};
+use crate::models::graph::MaximumIndependentSet;
+use crate::models::optimization::QUBO;
+use crate::rules::ReduceTo;
+use crate::topology::SimpleGraph;
+use crate::traits::Problem;
+use crate::types::ProblemSize;
+
+#[derive(Clone)]
+struct DummySource {
+    n: usize,
+}
+
+#[derive(Clone)]
+struct DummyTarget {
+    n: usize,
+}
+
+impl ProblemSpec for DummySource {
+    const NAME: &'static str = "DummySource";
+    type Value = i32;
+
+    fn variant_dimensions() -> Vec<VariantDimension> {
+        vec![VariantDimension::graph("SimpleGraph")]
+    }
+}
+
+impl ProblemSpec for DummyTarget {
+    const NAME: &'static str = "DummyTarget";
+    type Value = i32;
+
+    fn variant_dimensions() -> Vec<VariantDimension> {
+        vec![VariantDimension::graph("SimpleGraph")]
+    }
+}
+
+impl ProblemInstance for DummySource {
+    fn num_variables(&self) -> usize {
+        self.n
+    }
+
+    fn num_flavors(&self) -> usize {
+        2
+    }
+
+    fn size_profile(&self) -> ProblemSize {
+        ProblemSize::new(vec![("n", self.n)])
+    }
+
+    fn objective_direction(&self) -> ObjectiveDirection {
+        ObjectiveDirection::Maximize
+    }
+
+    fn evaluate_assignment(&self, assignment: &Assignment) -> Evaluation<Self::Value> {
+        let sum = assignment.as_slice().iter().copied().sum::<usize>() as i32;
+        Evaluation::feasible(sum)
+    }
+}
+
+impl ProblemInstance for DummyTarget {
+    fn num_variables(&self) -> usize {
+        self.n
+    }
+
+    fn num_flavors(&self) -> usize {
+        2
+    }
+
+    fn size_profile(&self) -> ProblemSize {
+        ProblemSize::new(vec![("n", self.n)])
+    }
+
+    fn objective_direction(&self) -> ObjectiveDirection {
+        ObjectiveDirection::Minimize
+    }
+
+    fn evaluate_assignment(&self, assignment: &Assignment) -> Evaluation<Self::Value> {
+        let sum = assignment.as_slice().iter().copied().sum::<usize>() as i32;
+        Evaluation::feasible(sum)
+    }
+}
+
+#[derive(Clone)]
+struct DummyReduction {
+    target: DummyTarget,
+}
+
+impl Reduction<DummySource, DummyTarget> for DummyReduction {
+    fn target_instance(&self) -> &DummyTarget {
+        &self.target
+    }
+
+    fn project_assignment(&self, target_solution: &Assignment) -> Assignment {
+        // Identity projection for contract test.
+        target_solution.clone()
+    }
+
+    fn source_size_profile(&self) -> ProblemSize {
+        ProblemSize::new(vec![("n", self.target.n)])
+    }
+
+    fn target_size_profile(&self) -> ProblemSize {
+        self.target.size_profile()
+    }
+}
+
+#[test]
+fn test_reduction_projection_round_trip_identity() {
+    let reduction = DummyReduction {
+        target: DummyTarget { n: 4 },
+    };
+    let assignment = Assignment::from(vec![1, 0, 1, 0]);
+    let projected = reduction.project_assignment(&assignment);
+    assert_eq!(projected, assignment);
+}
+
+#[test]
+fn test_legacy_problem_adapter_matches_legacy_evaluation() {
+    let legacy = MaximumIndependentSet::<SimpleGraph, i32>::new(3, vec![(0, 1), (1, 2)]);
+    let adapter = LegacyProblemAdapter::new(legacy.clone());
+    let assignment = Assignment::from(vec![1, 0, 1]);
+
+    let legacy_eval = legacy.solution_size(assignment.as_slice());
+    let new_eval = adapter.evaluate_assignment(&assignment);
+
+    assert_eq!(new_eval.objective, legacy_eval.size);
+    assert_eq!(new_eval.feasible, legacy_eval.is_valid);
+    assert_eq!(
+        adapter.objective_direction(),
+        ObjectiveDirection::from(legacy.energy_mode())
+    );
+}
+
+#[test]
+fn test_legacy_reduction_adapter_projection_and_sizes() {
+    let source = MaximumIndependentSet::<SimpleGraph, i32>::new(3, vec![(0, 1), (1, 2)]);
+    let legacy_reduction = ReduceTo::<QUBO<f64>>::reduce_to(&source);
+    let adapter = LegacyReductionAdapter::new(legacy_reduction);
+
+    let target_assignment = Assignment::from(vec![1, 0, 1]);
+    let projected = adapter.project_assignment(&target_assignment);
+
+    assert_eq!(projected, target_assignment);
+    assert_eq!(adapter.source_size_profile(), source.problem_size());
+    assert_eq!(
+        adapter.target_size_profile(),
+        adapter.target_instance().size_profile()
+    );
+}

--- a/src/unit_tests/contracts/variant.rs
+++ b/src/unit_tests/contracts/variant.rs
@@ -1,0 +1,35 @@
+use crate::core::{from_legacy_variant, VariantDimension, VariantKey};
+
+#[test]
+fn test_variant_round_trip_json() {
+    let dims = vec![
+        VariantDimension::graph("SimpleGraph"),
+        VariantDimension::weight("i32"),
+        VariantDimension::new(VariantKey::ConstParam("k".to_string()), "3"),
+    ];
+
+    let json = serde_json::to_string(&dims).unwrap();
+    let restored: Vec<VariantDimension> = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(dims, restored);
+}
+
+#[test]
+fn test_variant_legacy_mapping() {
+    let legacy = vec![
+        ("graph", "SimpleGraph"),
+        ("weight", "f64"),
+        ("domain", "sat"),
+    ];
+    let dims = from_legacy_variant(&legacy);
+
+    assert_eq!(dims[0].key, VariantKey::Graph);
+    assert_eq!(dims[0].key.legacy_key(), "graph");
+    assert_eq!(dims[0].value, "SimpleGraph");
+
+    assert_eq!(dims[1].key, VariantKey::Weight);
+    assert_eq!(dims[1].value, "f64");
+
+    assert_eq!(dims[2].key, VariantKey::Custom("domain".to_string()));
+    assert_eq!(dims[2].key.legacy_key(), "domain");
+}


### PR DESCRIPTION
## Summary

This PR delivers the first implementation slice of the types/interfaces redesign plan: a new v1 core contract layer added alongside existing APIs.

## Why

The project currently has higher contributor friction due to stringly-typed variants, repeated trait bounds, and mixed legacy abstractions.  
This PR establishes a stable, typed core surface before model/rule migration.

## What Changed

- Added new core module namespace:
  - `src/core/assignment.rs`
  - `src/core/evaluation.rs`
  - `src/core/objective.rs`
  - `src/core/variant.rs`
  - `src/core/problem.rs`
  - `src/core/reduction.rs`
  - `src/core/mod.rs`
- Introduced v1 primitives and contracts:
  - `Assignment`
  - `Evaluation<T>`
  - `ObjectiveValue`
  - `ObjectiveDirection`
  - `VariantKey` / `VariantDimension`
  - `ProblemSpec` / `ProblemInstance`
  - `Reduction<S, T>`
- Added compatibility adapters so legacy code remains usable:
  - `LegacyProblemAdapter<P>`
  - `LegacyReductionAdapter<R, S, T>`
- Re-exported new core API from crate root and prelude via `src/lib.rs`.
- Added contract-focused unit tests:
  - `src/unit_tests/contracts/*`
- Added normative contract documentation:
  - `docs/architecture/v1-contract.md`
- Added full implementation plan document:
  - `docs/plans/2026-02-11-types-interfaces-redesign-design.md`

## Compatibility

- No model/rule migrations in this PR.
- Legacy traits remain intact; new layer is additive.
- Existing behavior remains unchanged.

## Validation

- `cargo test -q` passed.
- `cargo clippy -q` passed (with one existing unrelated warning in `src/topology/grid_graph.rs`).

## Next Steps

- Migrate typed variant metadata through registry/macro paths.
- Unify graph taxonomy under the v1 contract.
- Begin representative model migrations using the new core interfaces.
