### PR TITLE
feat: add problem_size() to Problem trait with validation

### DIFF
--- a/benches/solver_benchmarks.rs
+++ b/benches/solver_benchmarks.rs
@@ -197,8 +197,10 @@ fn bench_comparison(c: &mut Criterion) {
     let solver = BruteForce::new();
 
     // MaximumIndependentSet with 8 vertices
-    let is_problem =
-        MaximumIndependentSet::new(SimpleGraph::new(8, vec![(0, 1), (2, 3), (4, 5), (6, 7)]), vec![1i32; 8]);
+    let is_problem = MaximumIndependentSet::new(
+        SimpleGraph::new(8, vec![(0, 1), (2, 3), (4, 5), (6, 7)]),
+        vec![1i32; 8],
+    );
     group.bench_function("MaximumIndependentSet", |b| {
         b.iter(|| solver.find_best(black_box(&is_problem)))
     });
@@ -228,7 +230,10 @@ fn bench_comparison(c: &mut Criterion) {
     });
 
     // MaxCut with 8 vertices
-    let mc_problem = MaxCut::new(SimpleGraph::new(8, vec![(0, 1), (2, 3), (4, 5), (6, 7)]), vec![1, 1, 1, 1]);
+    let mc_problem = MaxCut::new(
+        SimpleGraph::new(8, vec![(0, 1), (2, 3), (4, 5), (6, 7)]),
+        vec![1, 1, 1, 1],
+    );
     group.bench_function("MaxCut", |b| {
         b.iter(|| solver.find_best(black_box(&mc_problem)))
     });

--- a/docs/paper/reductions.typ
+++ b/docs/paper/reductions.typ
@@ -246,7 +246,7 @@
 ]
 
 #block(width: 100%, inset: (x: 2em, y: 1em))[
-  *Abstract.* We present formal definitions for computational problems and polynomial-time reductions implemented in the `problemreductions` library. For each reduction, we state theorems with constructive proofs that preserve solution structure.
+  *Abstract.* We present formal definitions for computational problems and polynomial-time reductions implemented in the `problem-reductions` library. For each reduction, we state theorems with constructive proofs that preserve solution structure.
 ]
 
 

--- a/docs/plans/2026-02-16-problem-size-trait-impl.md
+++ b/docs/plans/2026-02-16-problem-size-trait-impl.md
@@ -1,0 +1,577 @@
+# `problem_size()` Trait Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `fn problem_size(&self) -> ProblemSize` to the `Problem` trait, implement it for all 21 problem types, validate overhead polynomial variable names in `find_cheapest_path`, and test.
+
+**Architecture:** Add a required `problem_size(&self)` method to `Problem` trait. Each impl returns a `ProblemSize` with named components matching the overhead polynomial variable names used by `#[reduction(overhead = ...)]` annotations. Add `input_variable_names()` to `ReductionOverhead` to extract referenced variable names from polynomials. In `find_cheapest_path`, validate that overhead polynomial input variables are a subset of `source.problem_size()` component names — catching naming mismatches at path-finding time. Empty `input_size` skips validation for backward compatibility.
+
+**Tech Stack:** Rust, no new dependencies.
+
+---
+
+### Task 1: Add `problem_size()` to `Problem` trait
+
+**Files:**
+- Modify: `src/traits.rs:7-25`
+
+**Step 1: Add the method to the trait**
+
+In `src/traits.rs`, add after the `variant()` method (line 24):
+
+```rust
+    /// Named size components for overhead estimation in reduction path-finding.
+    fn problem_size(&self) -> crate::types::ProblemSize;
+```
+
+**Step 2: Verify it fails to compile (all 21 impls are now broken)**
+
+Run: `cargo check 2>&1 | head -5`
+Expected: errors about missing `problem_size` method in impls.
+
+**Step 3: Commit**
+
+```bash
+git add src/traits.rs
+git commit -m "feat: add problem_size() to Problem trait (compile-breaking)"
+```
+
+---
+
+### Task 2: Implement `problem_size()` for graph problems (9 types)
+
+All graph problems follow the same pattern: `num_vertices` from `self.graph().num_vertices()`, `num_edges` from `self.graph().num_edges()`. KColoring adds `num_colors`.
+
+**Files:**
+- Modify: `src/models/graph/maximum_independent_set.rs` (impl at ~line 93)
+- Modify: `src/models/graph/maximum_clique.rs` (impl at ~line 93)
+- Modify: `src/models/graph/minimum_vertex_cover.rs` (impl at ~line 88)
+- Modify: `src/models/graph/minimum_dominating_set.rs` (impl at ~line 113)
+- Modify: `src/models/graph/max_cut.rs` (impl at ~line 141)
+- Modify: `src/models/graph/maximum_matching.rs` (impl at ~line 161)
+- Modify: `src/models/graph/maximal_is.rs` (impl at ~line 127)
+- Modify: `src/models/graph/kcoloring.rs` (impl at ~line 120)
+- Modify: `src/models/graph/traveling_salesman.rs` (impl at ~line 124)
+
+**Step 1: Add `use crate::types::ProblemSize;` to each file** (if not already imported).
+
+**Step 2: Add `problem_size()` to each `impl Problem for` block**
+
+For MIS, MaxClique, MinVC, MinDS, MaximalIS, MaxCut, MaximumMatching, TravelingSalesman:
+```rust
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_vertices", self.graph().num_vertices()),
+            ("num_edges", self.graph().num_edges()),
+        ])
+    }
+```
+
+For KColoring (adds `num_colors`):
+```rust
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_vertices", self.graph().num_vertices()),
+            ("num_edges", self.graph().num_edges()),
+            ("num_colors", self.num_colors()),
+        ])
+    }
+```
+
+**Step 3: Verify graph models compile**
+
+Run: `cargo check 2>&1 | grep "error\[" | head -5`
+Expected: remaining errors only from non-graph models.
+
+**Step 4: Commit**
+
+```bash
+git add src/models/graph/
+git commit -m "feat: implement problem_size() for all graph problems"
+```
+
+---
+
+### Task 3: Implement `problem_size()` for SAT problems (2 types)
+
+**Files:**
+- Modify: `src/models/satisfiability/sat.rs` (impl at ~line 171)
+- Modify: `src/models/satisfiability/ksat.rs` (impl at ~line 161)
+
+**Step 1: Add import and implement for Satisfiability**
+
+```rust
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_vars", self.num_vars()),
+            ("num_clauses", self.num_clauses()),
+            ("num_literals", self.num_literals()),
+        ])
+    }
+```
+
+**Step 2: Implement for KSatisfiability**
+
+KSatisfiability does not have a `num_literals()` method. Compute inline:
+```rust
+    fn problem_size(&self) -> ProblemSize {
+        let num_literals: usize = self.clauses().iter().map(|c| c.len()).sum();
+        ProblemSize::new(vec![
+            ("num_vars", self.num_vars()),
+            ("num_clauses", self.num_clauses()),
+            ("num_literals", num_literals),
+        ])
+    }
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/models/satisfiability/
+git commit -m "feat: implement problem_size() for SAT problems"
+```
+
+---
+
+### Task 4: Implement `problem_size()` for set problems (2 types)
+
+**Files:**
+- Modify: `src/models/set/maximum_set_packing.rs` (impl at ~line 122)
+- Modify: `src/models/set/minimum_set_covering.rs` (impl at ~line 132)
+
+**Step 1: Implement for MaximumSetPacking**
+
+MaximumSetPacking has `num_sets()` but no `universe_size()`. Compute from sets:
+```rust
+    fn problem_size(&self) -> ProblemSize {
+        let universe_size = self.sets().iter()
+            .flat_map(|s| s.iter())
+            .max()
+            .map_or(0, |&m| m + 1);
+        ProblemSize::new(vec![
+            ("num_sets", self.num_sets()),
+            ("universe_size", universe_size),
+        ])
+    }
+```
+
+**Step 2: Implement for MinimumSetCovering**
+
+```rust
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_sets", self.num_sets()),
+            ("universe_size", self.universe_size()),
+        ])
+    }
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/models/set/
+git commit -m "feat: implement problem_size() for set problems"
+```
+
+---
+
+### Task 5: Implement `problem_size()` for optimization problems (3 types)
+
+**Files:**
+- Modify: `src/models/optimization/qubo.rs` (impl at ~line 146)
+- Modify: `src/models/optimization/spin_glass.rs` (impl at ~line 198)
+- Modify: `src/models/optimization/ilp.rs` (impl at ~line 330)
+
+**Step 1: Implement for QUBO**
+
+```rust
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![("num_vars", self.num_vars())])
+    }
+```
+
+**Step 2: Implement for SpinGlass**
+
+SpinGlass has `num_spins()` (= `graph.num_vertices()`). For `num_interactions`, use `graph.num_edges()`:
+```rust
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_spins", self.num_spins()),
+            ("num_interactions", self.graph().num_edges()),
+        ])
+    }
+```
+
+**Step 3: Implement for ILP**
+
+ILP has `num_variables()` and `self.constraints` (pub field):
+```rust
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_vars", self.num_variables()),
+            ("num_constraints", self.constraints.len()),
+        ])
+    }
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/models/optimization/
+git commit -m "feat: implement problem_size() for optimization problems"
+```
+
+---
+
+### Task 6: Implement `problem_size()` for specialized problems (5 types)
+
+**Files:**
+- Modify: `src/models/specialized/factoring.rs` (impl at ~line 116)
+- Modify: `src/models/specialized/circuit.rs` (impl at ~line 269)
+- Modify: `src/models/specialized/paintshop.rs` (impl at ~line 163)
+- Modify: `src/models/specialized/biclique_cover.rs` (impl at ~line 212)
+- Modify: `src/models/specialized/bmf.rs` (impl at ~line 193)
+
+**Step 1: Implement for Factoring**
+
+```rust
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_bits_first", self.m()),
+            ("num_bits_second", self.n()),
+        ])
+    }
+```
+
+**Step 2: Implement for CircuitSAT**
+
+CircuitSAT stores `variables: Vec<String>` and has `circuit.num_assignments()`:
+```rust
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_variables", self.num_variables()),
+            ("num_assignments", self.circuit().num_assignments()),
+        ])
+    }
+```
+
+Note: verify that `self.circuit()` and `self.num_variables()` exist; if `circuit` is private without accessor, use `self.variables.len()` for `num_variables`.
+
+**Step 3: Implement for PaintShop**
+
+```rust
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_cars", self.num_cars()),
+            ("num_sequence", self.sequence_len()),
+        ])
+    }
+```
+
+**Step 4: Add accessors to BicliqueCover**
+
+BicliqueCover has private `left_size` and `right_size` fields. Add public accessors:
+```rust
+    /// Get the left partition size.
+    pub fn left_size(&self) -> usize {
+        self.left_size
+    }
+
+    /// Get the right partition size.
+    pub fn right_size(&self) -> usize {
+        self.right_size
+    }
+```
+
+Then implement:
+```rust
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("left_size", self.left_size()),
+            ("right_size", self.right_size()),
+            ("num_edges", self.num_edges()),
+            ("rank", self.k()),
+        ])
+    }
+```
+
+**Step 5: Implement for BMF**
+
+BMF has `rows()`, `cols()`, `rank()`:
+```rust
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("m", self.rows()),
+            ("n", self.cols()),
+            ("rank", self.rank()),
+        ])
+    }
+```
+
+**Step 6: Verify full project compiles**
+
+Run: `cargo check --all-features`
+Expected: clean compile, no errors.
+
+**Step 7: Commit**
+
+```bash
+git add src/models/specialized/
+git commit -m "feat: implement problem_size() for specialized problems"
+```
+
+---
+
+### Task 7: Add overhead variable name validation in `find_cheapest_path`
+
+**Files:**
+- Modify: `src/polynomial.rs` (add `variable_names()` to `Polynomial`)
+- Modify: `src/rules/registry.rs` (add `input_variable_names()` to `ReductionOverhead`)
+- Modify: `src/rules/graph.rs` (add validation in `find_cheapest_path`)
+
+**Step 1: Add `variable_names()` to `Polynomial`**
+
+In `src/polynomial.rs`, add to `impl Polynomial`:
+```rust
+    /// Collect all variable names referenced by this polynomial.
+    pub fn variable_names(&self) -> HashSet<&'static str> {
+        self.terms.iter()
+            .flat_map(|m| m.variables.iter().map(|(name, _)| *name))
+            .collect()
+    }
+```
+
+Add `use std::collections::HashSet;` at the top of the file.
+
+**Step 2: Add `input_variable_names()` to `ReductionOverhead`**
+
+In `src/rules/registry.rs`, add to `impl ReductionOverhead`:
+```rust
+    /// Collect all input variable names referenced by the overhead polynomials.
+    pub fn input_variable_names(&self) -> HashSet<&'static str> {
+        self.output_size.iter()
+            .flat_map(|(_, poly)| poly.variable_names())
+            .collect()
+    }
+```
+
+Add `use std::collections::HashSet;` at the top.
+
+**Step 3: Add validation in `find_cheapest_path`**
+
+In `src/rules/graph.rs`, at the start of `find_cheapest_path`, after looking up the source node, validate that the `input_size` component names cover all overhead polynomial variables on outgoing edges. Skip validation when `input_size` is empty (backward compatibility):
+
+```rust
+    // Validate: when input_size is non-empty, check outgoing edges
+    if !input_size.components.is_empty() {
+        let size_names: std::collections::HashSet<&str> = input_size
+            .components.iter().map(|(k, _)| k.as_str()).collect();
+        for edge_ref in self.graph.edges(src) {
+            let missing: Vec<_> = edge_ref.weight().overhead
+                .input_variable_names()
+                .into_iter()
+                .filter(|name| !size_names.contains(name))
+                .collect();
+            if !missing.is_empty() {
+                let target_node = &self.nodes[self.graph[edge_ref.target()]];
+                panic!(
+                    "Overhead for {} -> {} references variables {:?} \
+                     not in source problem_size() components {:?}",
+                    source, target_node.name, missing, size_names,
+                );
+            }
+        }
+    }
+```
+
+**Step 4: Verify compiles**
+
+Run: `cargo check --all-features`
+
+**Step 5: Commit**
+
+```bash
+git add src/polynomial.rs src/rules/registry.rs src/rules/graph.rs
+git commit -m "feat: validate overhead variable names against problem_size in find_cheapest_path"
+```
+
+---
+
+### Task 8: Add unit tests for `problem_size()`
+
+**Files:**
+- Create: `src/unit_tests/problem_size.rs`
+- Modify: parent test module to include it via `#[path]` attribute
+
+**Step 1: Write tests**
+
+Create `src/unit_tests/problem_size.rs` with one test per problem category verifying component names and values match expectations. Example structure:
+
+```rust
+//! Tests for Problem::problem_size() implementations.
+
+use crate::models::graph::*;
+use crate::models::optimization::*;
+use crate::models::satisfiability::*;
+use crate::models::set::*;
+use crate::models::specialized::*;
+use crate::topology::SimpleGraph;
+use crate::traits::Problem;
+
+#[test]
+fn test_problem_size_mis() {
+    let g = SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]);
+    let mis = MaximumIndependentSet::<SimpleGraph, i32>::unweighted(g);
+    let size = mis.problem_size();
+    assert_eq!(size.get("num_vertices"), Some(4));
+    assert_eq!(size.get("num_edges"), Some(3));
+}
+
+#[test]
+fn test_problem_size_sat() {
+    use crate::models::satisfiability::CNFClause;
+    let sat = Satisfiability::new(3, vec![
+        CNFClause::new(vec![1, -2]),
+        CNFClause::new(vec![2, 3]),
+    ]);
+    let size = sat.problem_size();
+    assert_eq!(size.get("num_vars"), Some(3));
+    assert_eq!(size.get("num_clauses"), Some(2));
+    assert_eq!(size.get("num_literals"), Some(4));
+}
+
+#[test]
+fn test_problem_size_qubo() {
+    let qubo = QUBO::<f64>::new(vec![1.0, 2.0, 3.0], vec![]);
+    let size = qubo.problem_size();
+    assert_eq!(size.get("num_vars"), Some(3));
+}
+
+#[test]
+fn test_problem_size_spinglass() {
+    let sg = SpinGlass::<SimpleGraph, f64>::new(
+        3,
+        vec![((0, 1), 1.0), ((1, 2), -1.0)],
+        vec![0.0, 0.5, -0.5],
+    );
+    let size = sg.problem_size();
+    assert_eq!(size.get("num_spins"), Some(3));
+    assert_eq!(size.get("num_interactions"), Some(2));
+}
+
+#[test]
+fn test_problem_size_factoring() {
+    let f = Factoring::new(2, 3, 6);
+    let size = f.problem_size();
+    assert_eq!(size.get("num_bits_first"), Some(2));
+    assert_eq!(size.get("num_bits_second"), Some(3));
+}
+
+#[test]
+fn test_problem_size_bmf() {
+    let bmf = BMF::new(vec![vec![true, false], vec![false, true]], 2);
+    let size = bmf.problem_size();
+    assert_eq!(size.get("m"), Some(2));
+    assert_eq!(size.get("n"), Some(2));
+    assert_eq!(size.get("rank"), Some(2));
+}
+```
+
+Add similar tests for: MaxCut, KColoring, MaximumSetPacking, MinimumSetCovering, ILP, CircuitSAT, PaintShop, BicliqueCover. Each test creates a small instance and asserts the expected component names and values.
+
+**Step 2: Wire the test module**
+
+Find where unit test modules are declared (likely in `src/lib.rs` via `#[path]` attribute) and add:
+```rust
+#[cfg(test)]
+#[path = "unit_tests/problem_size.rs"]
+mod problem_size_tests;
+```
+
+**Step 3: Run tests**
+
+Run: `cargo test --all-features problem_size`
+Expected: all tests pass.
+
+**Step 4: Commit**
+
+```bash
+git add src/unit_tests/problem_size.rs src/lib.rs
+git commit -m "test: add problem_size() unit tests for all 21 problem types"
+```
+
+---
+
+### Task 9: Add integration test for `find_cheapest_path` with `problem_size`
+
+**Files:**
+- Modify: `src/unit_tests/rules/reduction_path_parity.rs`
+
+**Step 1: Add test using `find_cheapest_path` with real problem size**
+
+```rust
+#[test]
+fn test_find_cheapest_path_with_problem_size() {
+    let graph = ReductionGraph::new();
+    let petersen = SimpleGraph::new(10, vec![
+        (0,1),(0,4),(0,5),(1,2),(1,6),(2,3),(2,7),
+        (3,4),(3,8),(4,9),(5,7),(5,8),(6,8),(6,9),(7,9),
+    ]);
+    let source = MaxCut::<SimpleGraph, i32>::unweighted(petersen);
+    let src_var = ReductionGraph::variant_to_map(&MaxCut::<SimpleGraph, i32>::variant());
+    let dst_var = ReductionGraph::variant_to_map(&SpinGlass::<SimpleGraph, f64>::variant());
+
+    // Use source.problem_size() instead of ProblemSize::new(vec![])
+    let rpath = graph
+        .find_cheapest_path(
+            "MaxCut", &src_var,
+            "SpinGlass", &dst_var,
+            &source.problem_size(),
+            &MinimizeSteps,
+        )
+        .expect("Should find path MaxCut -> SpinGlass");
+
+    assert!(!rpath.type_names().is_empty());
+
+    // Verify problem_size has expected components
+    let size = source.problem_size();
+    assert_eq!(size.get("num_vertices"), Some(10));
+    assert_eq!(size.get("num_edges"), Some(15));
+}
+```
+
+**Step 2: Run test**
+
+Run: `cargo test --all-features find_cheapest_path_with_problem_size`
+Expected: pass (validation passes because MaxCut's components match overhead polynomial vars).
+
+**Step 3: Commit**
+
+```bash
+git add src/unit_tests/
+git commit -m "test: add find_cheapest_path integration test with problem_size"
+```
+
+---
+
+### Task 10: Run full test suite and clippy
+
+**Step 1: Run tests**
+
+Run: `make test`
+Expected: all tests pass.
+
+**Step 2: Run clippy**
+
+Run: `make clippy`
+Expected: no warnings.
+
+**Step 3: Run fmt**
+
+Run: `make fmt`
+
+**Step 4: Final commit if any formatting changes**
+
+```bash
+git add -A && git commit -m "chore: format"
+```

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -68,11 +68,26 @@ and MaximumIndependentSet:
 {{#include ../../examples/chained_reduction_ksat_to_mis.rs:imports}}
 
 {{#include ../../examples/chained_reduction_ksat_to_mis.rs:example}}
+
+{{#include ../../examples/chained_reduction_ksat_to_mis.rs:overhead}}
 ```
 
 The `ExecutablePath` handles variant casts (e.g., `K3` → `KN`) and
 cross-problem reductions (e.g., SAT → MIS) uniformly. The `ChainedReduction`
 extracts solutions back through the entire chain in one call.
+
+`compose_path_overhead` composes the per-step polynomial overheads into a
+symbolic formula mapping source variables to final target variables:
+
+```text
+  num_vertices = num_literals
+  num_edges = num_literals^2
+```
+
+This result comes from composing two steps: KSatisfiability → Satisfiability
+is identity (same size fields), then Satisfiability → MIS maps
+`num_vertices = num_literals` and `num_edges = num_literals²`.
+Substituting the identity through gives the final polynomials above.
 
 ## Solvers
 

--- a/examples/chained_reduction_factoring_to_spinglass.rs
+++ b/examples/chained_reduction_factoring_to_spinglass.rs
@@ -18,8 +18,7 @@ pub fn run() {
 
     // Find reduction path: Factoring -> ... -> SpinGlass
     let src_var = ReductionGraph::variant_to_map(&Factoring::variant());
-    let dst_var =
-        ReductionGraph::variant_to_map(&SpinGlass::<SimpleGraph, f64>::variant());
+    let dst_var = ReductionGraph::variant_to_map(&SpinGlass::<SimpleGraph, f64>::variant());
     let rpath = graph
         .find_cheapest_path(
             "Factoring",

--- a/examples/chained_reduction_ksat_to_mis.rs
+++ b/examples/chained_reduction_ksat_to_mis.rs
@@ -57,6 +57,16 @@ pub fn run() {
     // Verify: satisfies the original 3-SAT formula
     assert!(ksat.evaluate(&original));
     // ANCHOR_END: example
+
+    // ANCHOR: overhead
+    // Compose overheads symbolically along the path
+    // Maps source problem variables → final target problem variables
+    let composed = graph.compose_path_overhead(&rpath);
+    for (field, poly) in &composed.output_size {
+        println!("  {} = {}", field, poly);
+    }
+    // ANCHOR_END: overhead
+
     println!("3-SAT solution: {:?}", original);
     println!("Reduction path: {:?}", rpath.type_names());
 }

--- a/examples/reduction_maximumclique_to_ilp.rs
+++ b/examples/reduction_maximumclique_to_ilp.rs
@@ -22,7 +22,10 @@ use problemreductions::topology::{Graph, SimpleGraph};
 pub fn run() {
     // 1. Create MaximumClique instance: Octahedron (K_{2,2,2}), 6 vertices, 12 edges, clique number 3
     let (num_vertices, edges) = octahedral();
-    let clique = MaximumClique::new(SimpleGraph::new(num_vertices, edges.clone()), vec![1i32; num_vertices]);
+    let clique = MaximumClique::new(
+        SimpleGraph::new(num_vertices, edges.clone()),
+        vec![1i32; num_vertices],
+    );
 
     // 2. Reduce to ILP
     let reduction = ReduceTo::<ILP>::reduce_to(&clique);

--- a/examples/reduction_maximumindependentset_to_ilp.rs
+++ b/examples/reduction_maximumindependentset_to_ilp.rs
@@ -21,7 +21,10 @@ use problemreductions::topology::{Graph, SimpleGraph};
 pub fn run() {
     // 1. Create IS instance: Petersen graph
     let (num_vertices, edges) = petersen();
-    let is = MaximumIndependentSet::new(SimpleGraph::new(num_vertices, edges.clone()), vec![1i32; num_vertices]);
+    let is = MaximumIndependentSet::new(
+        SimpleGraph::new(num_vertices, edges.clone()),
+        vec![1i32; num_vertices],
+    );
 
     // 2. Reduce to ILP
     let reduction = ReduceTo::<ILP>::reduce_to(&is);

--- a/examples/reduction_maximumindependentset_to_maximumsetpacking.rs
+++ b/examples/reduction_maximumindependentset_to_maximumsetpacking.rs
@@ -25,7 +25,10 @@ pub fn run() {
 
     // Petersen graph: 10 vertices, 15 edges, 3-regular
     let (num_vertices, edges) = petersen();
-    let source = MaximumIndependentSet::new(SimpleGraph::new(num_vertices, edges.clone()), vec![1i32; num_vertices]);
+    let source = MaximumIndependentSet::new(
+        SimpleGraph::new(num_vertices, edges.clone()),
+        vec![1i32; num_vertices],
+    );
 
     println!("Source: MaximumIndependentSet on Petersen graph");
     println!("  Vertices: {}", num_vertices);

--- a/examples/reduction_maximumindependentset_to_minimumvertexcover.rs
+++ b/examples/reduction_maximumindependentset_to_minimumvertexcover.rs
@@ -22,7 +22,10 @@ use problemreductions::topology::{Graph, SimpleGraph};
 pub fn run() {
     // 1. Create IS instance: Petersen graph
     let (num_vertices, edges) = petersen();
-    let is = MaximumIndependentSet::new(SimpleGraph::new(num_vertices, edges.clone()), vec![1i32; num_vertices]);
+    let is = MaximumIndependentSet::new(
+        SimpleGraph::new(num_vertices, edges.clone()),
+        vec![1i32; num_vertices],
+    );
 
     // 2. Reduce to VC
     let reduction = ReduceTo::<MinimumVertexCover<SimpleGraph, i32>>::reduce_to(&is);

--- a/examples/reduction_maximumindependentset_to_qubo.rs
+++ b/examples/reduction_maximumindependentset_to_qubo.rs
@@ -34,7 +34,10 @@ pub fn run() {
 
     // Petersen graph: 10 vertices, 15 edges, 3-regular
     let (num_vertices, edges) = petersen();
-    let is = MaximumIndependentSet::new(SimpleGraph::new(num_vertices, edges.clone()), vec![1i32; num_vertices]);
+    let is = MaximumIndependentSet::new(
+        SimpleGraph::new(num_vertices, edges.clone()),
+        vec![1i32; num_vertices],
+    );
 
     // Reduce to QUBO
     let reduction = ReduceTo::<QUBO>::reduce_to(&is);

--- a/examples/reduction_maximummatching_to_ilp.rs
+++ b/examples/reduction_maximummatching_to_ilp.rs
@@ -21,7 +21,8 @@ use problemreductions::topology::{Graph, SimpleGraph};
 pub fn run() {
     // 1. Create MaximumMatching instance: Petersen graph with unit weights
     let (num_vertices, edges) = petersen();
-    let matching = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(num_vertices, edges.clone()));
+    let matching =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(num_vertices, edges.clone()));
 
     // 2. Reduce to ILP
     let reduction = ReduceTo::<ILP>::reduce_to(&matching);

--- a/examples/reduction_maximummatching_to_maximumsetpacking.rs
+++ b/examples/reduction_maximummatching_to_maximumsetpacking.rs
@@ -25,7 +25,8 @@ pub fn run() {
 
     // Petersen graph with unit weights
     let (num_vertices, edges) = petersen();
-    let source = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(num_vertices, edges.clone()));
+    let source =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(num_vertices, edges.clone()));
 
     println!("Source: MaximumMatching on Petersen graph");
     println!("  Vertices: {}", num_vertices);

--- a/examples/reduction_minimumdominatingset_to_ilp.rs
+++ b/examples/reduction_minimumdominatingset_to_ilp.rs
@@ -21,7 +21,10 @@ use problemreductions::topology::{Graph, SimpleGraph};
 pub fn run() {
     // 1. Create MinimumDominatingSet instance: Petersen graph
     let (num_vertices, edges) = petersen();
-    let ds = MinimumDominatingSet::new(SimpleGraph::new(num_vertices, edges.clone()), vec![1i32; num_vertices]);
+    let ds = MinimumDominatingSet::new(
+        SimpleGraph::new(num_vertices, edges.clone()),
+        vec![1i32; num_vertices],
+    );
 
     // 2. Reduce to ILP
     let reduction = ReduceTo::<ILP>::reduce_to(&ds);

--- a/examples/reduction_minimumvertexcover_to_ilp.rs
+++ b/examples/reduction_minimumvertexcover_to_ilp.rs
@@ -21,7 +21,10 @@ use problemreductions::topology::{Graph, SimpleGraph};
 pub fn run() {
     // 1. Create VC instance: Petersen graph (10 vertices, 15 edges), VC=6
     let (num_vertices, edges) = petersen();
-    let vc = MinimumVertexCover::new(SimpleGraph::new(num_vertices, edges.clone()), vec![1i32; num_vertices]);
+    let vc = MinimumVertexCover::new(
+        SimpleGraph::new(num_vertices, edges.clone()),
+        vec![1i32; num_vertices],
+    );
 
     // 2. Reduce to ILP
     let reduction = ReduceTo::<ILP>::reduce_to(&vc);

--- a/examples/reduction_minimumvertexcover_to_maximumindependentset.rs
+++ b/examples/reduction_minimumvertexcover_to_maximumindependentset.rs
@@ -23,7 +23,10 @@ use problemreductions::topology::{Graph, SimpleGraph};
 pub fn run() {
     // Petersen graph: 10 vertices, 15 edges, VC=6
     let (num_vertices, edges) = petersen();
-    let vc = MinimumVertexCover::new(SimpleGraph::new(num_vertices, edges.clone()), vec![1i32; num_vertices]);
+    let vc = MinimumVertexCover::new(
+        SimpleGraph::new(num_vertices, edges.clone()),
+        vec![1i32; num_vertices],
+    );
 
     let reduction = ReduceTo::<MaximumIndependentSet<SimpleGraph, i32>>::reduce_to(&vc);
     let is = reduction.target_problem();

--- a/examples/reduction_minimumvertexcover_to_minimumsetcovering.rs
+++ b/examples/reduction_minimumvertexcover_to_minimumsetcovering.rs
@@ -25,7 +25,10 @@ pub fn run() {
 
     // Petersen graph: 10 vertices, 15 edges, VC=6
     let (num_vertices, edges) = petersen();
-    let source = MinimumVertexCover::new(SimpleGraph::new(num_vertices, edges.clone()), vec![1i32; num_vertices]);
+    let source = MinimumVertexCover::new(
+        SimpleGraph::new(num_vertices, edges.clone()),
+        vec![1i32; num_vertices],
+    );
 
     println!("Source: MinimumVertexCover on Petersen graph");
     println!("  Vertices: {}", num_vertices);

--- a/examples/reduction_minimumvertexcover_to_qubo.rs
+++ b/examples/reduction_minimumvertexcover_to_qubo.rs
@@ -34,7 +34,10 @@ pub fn run() {
 
     // Petersen graph: 10 vertices, 15 edges, VC=6
     let (num_vertices, edges) = petersen();
-    let vc = MinimumVertexCover::new(SimpleGraph::new(num_vertices, edges.clone()), vec![1i32; num_vertices]);
+    let vc = MinimumVertexCover::new(
+        SimpleGraph::new(num_vertices, edges.clone()),
+        vec![1i32; num_vertices],
+    );
 
     // Reduce to QUBO
     let reduction = ReduceTo::<QUBO>::reduce_to(&vc);

--- a/problemreductions-macros/src/lib.rs
+++ b/problemreductions-macros/src/lib.rs
@@ -187,6 +187,8 @@ fn generate_reduction_entry(
                 target_variant_fn: || { #target_variant_body },
                 overhead_fn: || { #overhead },
                 module_path: module_path!(),
+                source_size_names_fn: || { <#source_type as crate::traits::Problem>::problem_size_names() },
+                target_size_names_fn: || { <#target_type as crate::traits::Problem>::problem_size_names() },
                 reduce_fn: |src: &dyn std::any::Any| -> Box<dyn crate::rules::traits::DynReductionResult> {
                     let src = src.downcast_ref::<#source_type>().unwrap_or_else(|| {
                         panic!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,9 @@ pub use problemreductions_macros::reduction;
 #[path = "unit_tests/graph_models.rs"]
 mod test_graph_models;
 #[cfg(test)]
+#[path = "unit_tests/problem_size.rs"]
+mod test_problem_size;
+#[cfg(test)]
 #[path = "unit_tests/property.rs"]
 mod test_property;
 #[cfg(test)]
@@ -131,6 +134,3 @@ mod test_trait_consistency;
 #[cfg(test)]
 #[path = "unit_tests/unitdiskmapping_algorithms/mod.rs"]
 mod test_unitdiskmapping_algorithms;
-#[cfg(test)]
-#[path = "unit_tests/problem_size.rs"]
-mod test_problem_size;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,3 +131,6 @@ mod test_trait_consistency;
 #[cfg(test)]
 #[path = "unit_tests/unitdiskmapping_algorithms/mod.rs"]
 mod test_unitdiskmapping_algorithms;
+#[cfg(test)]
+#[path = "unit_tests/problem_size.rs"]
+mod test_problem_size;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub mod prelude {
     pub use crate::registry::{ComplexityClass, ProblemInfo, ProblemMetadata};
     pub use crate::rules::{ReduceTo, ReductionResult};
     pub use crate::solvers::{BruteForce, Solver};
-    pub use crate::traits::{OptimizationProblem, Problem, SatisfactionProblem};
+    pub use crate::traits::{problem_size, OptimizationProblem, Problem, SatisfactionProblem};
     pub use crate::types::{
         Direction, NumericSize, One, ProblemSize, SolutionSize, Unweighted, WeightElement,
     };
@@ -108,7 +108,7 @@ pub mod prelude {
 pub use error::{ProblemError, Result};
 pub use registry::{ComplexityClass, ProblemInfo};
 pub use solvers::{BruteForce, Solver};
-pub use traits::{OptimizationProblem, Problem, SatisfactionProblem};
+pub use traits::{problem_size, OptimizationProblem, Problem, SatisfactionProblem};
 pub use types::{
     Direction, NumericSize, One, ProblemSize, SolutionSize, Unweighted, WeightElement,
 };

--- a/src/models/graph/kcoloring.rs
+++ b/src/models/graph/kcoloring.rs
@@ -6,6 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{Problem, SatisfactionProblem};
+use crate::types::ProblemSize;
 use crate::variant::{KValue, VariantParam, KN};
 use serde::{Deserialize, Serialize};
 
@@ -134,6 +135,14 @@ where
 
     fn evaluate(&self, config: &[usize]) -> bool {
         self.is_valid_coloring(config)
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_vertices", self.graph().num_vertices()),
+            ("num_edges", self.graph().num_edges()),
+            ("num_colors", self.num_colors()),
+        ])
     }
 }
 

--- a/src/models/graph/kcoloring.rs
+++ b/src/models/graph/kcoloring.rs
@@ -6,7 +6,6 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{Problem, SatisfactionProblem};
-use crate::types::ProblemSize;
 use crate::variant::{KValue, VariantParam, KN};
 use serde::{Deserialize, Serialize};
 
@@ -137,12 +136,11 @@ where
         self.is_valid_coloring(config)
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("num_vertices", self.graph().num_vertices()),
-            ("num_edges", self.graph().num_edges()),
-            ("num_colors", self.num_colors()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vertices", "num_edges"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.graph().num_vertices(), self.graph().num_edges()]
     }
 }
 

--- a/src/models/graph/max_cut.rs
+++ b/src/models/graph/max_cut.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
+use crate::types::{Direction, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -160,11 +160,11 @@ where
         SolutionSize::Valid(cut_size(&self.graph, &self.edge_weights, &partition))
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("num_vertices", self.graph().num_vertices()),
-            ("num_edges", self.graph().num_edges()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vertices", "num_edges"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.graph().num_vertices(), self.graph().num_edges()]
     }
 }
 

--- a/src/models/graph/max_cut.rs
+++ b/src/models/graph/max_cut.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize, WeightElement};
+use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -158,6 +158,13 @@ where
         // All cuts are valid, so always return Valid
         let partition: Vec<bool> = config.iter().map(|&c| c != 0).collect();
         SolutionSize::Valid(cut_size(&self.graph, &self.edge_weights, &partition))
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_vertices", self.graph().num_vertices()),
+            ("num_edges", self.graph().num_edges()),
+        ])
     }
 }
 

--- a/src/models/graph/maximal_is.rs
+++ b/src/models/graph/maximal_is.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize, WeightElement};
+use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -151,6 +151,13 @@ where
             }
         }
         SolutionSize::Valid(total)
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_vertices", self.graph().num_vertices()),
+            ("num_edges", self.graph().num_edges()),
+        ])
     }
 }
 

--- a/src/models/graph/maximal_is.rs
+++ b/src/models/graph/maximal_is.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
+use crate::types::{Direction, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -153,11 +153,11 @@ where
         SolutionSize::Valid(total)
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("num_vertices", self.graph().num_vertices()),
-            ("num_edges", self.graph().num_edges()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vertices", "num_edges"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.graph().num_vertices(), self.graph().num_edges()]
     }
 }
 

--- a/src/models/graph/maximum_clique.rs
+++ b/src/models/graph/maximum_clique.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize, WeightElement};
+use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -117,6 +117,13 @@ where
             }
         }
         SolutionSize::Valid(total)
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_vertices", self.graph().num_vertices()),
+            ("num_edges", self.graph().num_edges()),
+        ])
     }
 }
 

--- a/src/models/graph/maximum_clique.rs
+++ b/src/models/graph/maximum_clique.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
+use crate::types::{Direction, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -119,11 +119,11 @@ where
         SolutionSize::Valid(total)
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("num_vertices", self.graph().num_vertices()),
-            ("num_edges", self.graph().num_edges()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vertices", "num_edges"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.graph().num_vertices(), self.graph().num_edges()]
     }
 }
 

--- a/src/models/graph/maximum_independent_set.rs
+++ b/src/models/graph/maximum_independent_set.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize, WeightElement};
+use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -117,6 +117,13 @@ where
             }
         }
         SolutionSize::Valid(total)
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_vertices", self.graph().num_vertices()),
+            ("num_edges", self.graph().num_edges()),
+        ])
     }
 }
 

--- a/src/models/graph/maximum_independent_set.rs
+++ b/src/models/graph/maximum_independent_set.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
+use crate::types::{Direction, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -119,11 +119,11 @@ where
         SolutionSize::Valid(total)
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("num_vertices", self.graph().num_vertices()),
-            ("num_edges", self.graph().num_edges()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vertices", "num_edges"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.graph().num_vertices(), self.graph().num_edges()]
     }
 }
 

--- a/src/models/graph/maximum_matching.rs
+++ b/src/models/graph/maximum_matching.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
+use crate::types::{Direction, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -189,11 +189,11 @@ where
         SolutionSize::Valid(total)
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("num_vertices", self.graph().num_vertices()),
-            ("num_edges", self.graph().num_edges()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vertices", "num_edges"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.graph().num_vertices(), self.graph().num_edges()]
     }
 }
 

--- a/src/models/graph/maximum_matching.rs
+++ b/src/models/graph/maximum_matching.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize, WeightElement};
+use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -187,6 +187,13 @@ where
             }
         }
         SolutionSize::Valid(total)
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_vertices", self.graph().num_vertices()),
+            ("num_edges", self.graph().num_edges()),
+        ])
     }
 }
 

--- a/src/models/graph/minimum_dominating_set.rs
+++ b/src/models/graph/minimum_dominating_set.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
+use crate::types::{Direction, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -139,11 +139,11 @@ where
         SolutionSize::Valid(total)
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("num_vertices", self.graph().num_vertices()),
-            ("num_edges", self.graph().num_edges()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vertices", "num_edges"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.graph().num_vertices(), self.graph().num_edges()]
     }
 }
 

--- a/src/models/graph/minimum_dominating_set.rs
+++ b/src/models/graph/minimum_dominating_set.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize, WeightElement};
+use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -137,6 +137,13 @@ where
             }
         }
         SolutionSize::Valid(total)
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_vertices", self.graph().num_vertices()),
+            ("num_edges", self.graph().num_edges()),
+        ])
     }
 }
 

--- a/src/models/graph/minimum_vertex_cover.rs
+++ b/src/models/graph/minimum_vertex_cover.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
+use crate::types::{Direction, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -114,11 +114,11 @@ where
         SolutionSize::Valid(total)
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("num_vertices", self.graph().num_vertices()),
-            ("num_edges", self.graph().num_edges()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vertices", "num_edges"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.graph().num_vertices(), self.graph().num_edges()]
     }
 }
 

--- a/src/models/graph/minimum_vertex_cover.rs
+++ b/src/models/graph/minimum_vertex_cover.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize, WeightElement};
+use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -112,6 +112,13 @@ where
             }
         }
         SolutionSize::Valid(total)
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_vertices", self.graph().num_vertices()),
+            ("num_edges", self.graph().num_edges()),
+        ])
     }
 }
 

--- a/src/models/graph/traveling_salesman.rs
+++ b/src/models/graph/traveling_salesman.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
+use crate::types::{Direction, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -152,11 +152,11 @@ where
         SolutionSize::Valid(total)
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("num_vertices", self.graph().num_vertices()),
-            ("num_edges", self.graph().num_edges()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vertices", "num_edges"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.graph().num_vertices(), self.graph().num_edges()]
     }
 }
 

--- a/src/models/graph/traveling_salesman.rs
+++ b/src/models/graph/traveling_salesman.rs
@@ -6,7 +6,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::Graph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize, WeightElement};
+use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -150,6 +150,13 @@ where
             }
         }
         SolutionSize::Valid(total)
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_vertices", self.graph().num_vertices()),
+            ("num_edges", self.graph().num_edges()),
+        ])
     }
 }
 

--- a/src/models/optimization/ilp.rs
+++ b/src/models/optimization/ilp.rs
@@ -5,7 +5,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize};
+use crate::types::{Direction, ProblemSize, SolutionSize};
 use serde::{Deserialize, Serialize};
 
 inventory::submit! {
@@ -352,6 +352,13 @@ impl Problem for ILP {
 
     fn variant() -> Vec<(&'static str, &'static str)> {
         crate::variant_params![]
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_vars", self.num_variables()),
+            ("num_constraints", self.constraints.len()),
+        ])
     }
 }
 

--- a/src/models/optimization/ilp.rs
+++ b/src/models/optimization/ilp.rs
@@ -5,7 +5,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize};
+use crate::types::{Direction, SolutionSize};
 use serde::{Deserialize, Serialize};
 
 inventory::submit! {
@@ -354,11 +354,11 @@ impl Problem for ILP {
         crate::variant_params![]
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("num_vars", self.num_variables()),
-            ("num_constraints", self.constraints.len()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vars", "num_constraints"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.num_variables(), self.constraints.len()]
     }
 }
 

--- a/src/models/optimization/qubo.rs
+++ b/src/models/optimization/qubo.rs
@@ -4,7 +4,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
+use crate::types::{Direction, SolutionSize, WeightElement};
 use serde::{Deserialize, Serialize};
 
 inventory::submit! {
@@ -169,8 +169,11 @@ where
         crate::variant_params![W]
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![("num_vars", self.num_vars())])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vars"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.num_vars()]
     }
 }
 

--- a/src/models/optimization/qubo.rs
+++ b/src/models/optimization/qubo.rs
@@ -4,7 +4,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize, WeightElement};
+use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
 use serde::{Deserialize, Serialize};
 
 inventory::submit! {
@@ -167,6 +167,10 @@ where
 
     fn variant() -> Vec<(&'static str, &'static str)> {
         crate::variant_params![W]
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![("num_vars", self.num_vars())])
     }
 }
 

--- a/src/models/optimization/spin_glass.rs
+++ b/src/models/optimization/spin_glass.rs
@@ -5,7 +5,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::{Graph, SimpleGraph};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize, WeightElement};
+use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
 use serde::{Deserialize, Serialize};
 
 inventory::submit! {
@@ -222,6 +222,13 @@ where
 
     fn variant() -> Vec<(&'static str, &'static str)> {
         crate::variant_params![G, W]
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_spins", self.num_spins()),
+            ("num_interactions", self.graph().num_edges()),
+        ])
     }
 }
 

--- a/src/models/optimization/spin_glass.rs
+++ b/src/models/optimization/spin_glass.rs
@@ -5,7 +5,7 @@
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::topology::{Graph, SimpleGraph};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
+use crate::types::{Direction, SolutionSize, WeightElement};
 use serde::{Deserialize, Serialize};
 
 inventory::submit! {
@@ -224,11 +224,11 @@ where
         crate::variant_params![G, W]
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("num_spins", self.num_spins()),
-            ("num_interactions", self.graph().num_edges()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_spins", "num_interactions"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.num_spins(), self.graph().num_edges()]
     }
 }
 

--- a/src/models/satisfiability/ksat.rs
+++ b/src/models/satisfiability/ksat.rs
@@ -7,7 +7,6 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{Problem, SatisfactionProblem};
-use crate::types::ProblemSize;
 use crate::variant::KValue;
 use serde::{Deserialize, Serialize};
 
@@ -172,13 +171,12 @@ impl<K: KValue> Problem for KSatisfiability<K> {
         self.is_satisfying(&assignment)
     }
 
-    fn problem_size(&self) -> ProblemSize {
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vars", "num_clauses", "num_literals"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
         let num_literals: usize = self.clauses().iter().map(|c| c.len()).sum();
-        ProblemSize::new(vec![
-            ("num_vars", self.num_vars()),
-            ("num_clauses", self.num_clauses()),
-            ("num_literals", num_literals),
-        ])
+        vec![self.num_vars(), self.num_clauses(), num_literals]
     }
 
     fn variant() -> Vec<(&'static str, &'static str)> {

--- a/src/models/satisfiability/ksat.rs
+++ b/src/models/satisfiability/ksat.rs
@@ -7,6 +7,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{Problem, SatisfactionProblem};
+use crate::types::ProblemSize;
 use crate::variant::KValue;
 use serde::{Deserialize, Serialize};
 
@@ -169,6 +170,15 @@ impl<K: KValue> Problem for KSatisfiability<K> {
     fn evaluate(&self, config: &[usize]) -> bool {
         let assignment = Self::config_to_assignment(config);
         self.is_satisfying(&assignment)
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        let num_literals: usize = self.clauses().iter().map(|c| c.len()).sum();
+        ProblemSize::new(vec![
+            ("num_vars", self.num_vars()),
+            ("num_clauses", self.num_clauses()),
+            ("num_literals", num_literals),
+        ])
     }
 
     fn variant() -> Vec<(&'static str, &'static str)> {

--- a/src/models/satisfiability/sat.rs
+++ b/src/models/satisfiability/sat.rs
@@ -7,6 +7,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{Problem, SatisfactionProblem};
+use crate::types::ProblemSize;
 use serde::{Deserialize, Serialize};
 
 inventory::submit! {
@@ -179,6 +180,14 @@ impl Problem for Satisfiability {
     fn evaluate(&self, config: &[usize]) -> bool {
         let assignment = Self::config_to_assignment(config);
         self.is_satisfying(&assignment)
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_vars", self.num_vars()),
+            ("num_clauses", self.num_clauses()),
+            ("num_literals", self.num_literals()),
+        ])
     }
 
     fn variant() -> Vec<(&'static str, &'static str)> {

--- a/src/models/satisfiability/sat.rs
+++ b/src/models/satisfiability/sat.rs
@@ -7,7 +7,6 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{Problem, SatisfactionProblem};
-use crate::types::ProblemSize;
 use serde::{Deserialize, Serialize};
 
 inventory::submit! {
@@ -182,12 +181,11 @@ impl Problem for Satisfiability {
         self.is_satisfying(&assignment)
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("num_vars", self.num_vars()),
-            ("num_clauses", self.num_clauses()),
-            ("num_literals", self.num_literals()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vars", "num_clauses", "num_literals"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.num_vars(), self.num_clauses(), self.num_literals()]
     }
 
     fn variant() -> Vec<(&'static str, &'static str)> {

--- a/src/models/set/maximum_set_packing.rs
+++ b/src/models/set/maximum_set_packing.rs
@@ -5,7 +5,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
+use crate::types::{Direction, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -147,17 +147,17 @@ where
         crate::variant_params![W]
     }
 
-    fn problem_size(&self) -> ProblemSize {
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_sets", "universe_size"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
         let universe_size = self
             .sets()
             .iter()
             .flat_map(|s| s.iter())
             .max()
             .map_or(0, |&m| m + 1);
-        ProblemSize::new(vec![
-            ("num_sets", self.num_sets()),
-            ("universe_size", universe_size),
-        ])
+        vec![self.num_sets(), universe_size]
     }
 }
 

--- a/src/models/set/maximum_set_packing.rs
+++ b/src/models/set/maximum_set_packing.rs
@@ -148,7 +148,9 @@ where
     }
 
     fn problem_size(&self) -> ProblemSize {
-        let universe_size = self.sets().iter()
+        let universe_size = self
+            .sets()
+            .iter()
             .flat_map(|s| s.iter())
             .max()
             .map_or(0, |&m| m + 1);

--- a/src/models/set/maximum_set_packing.rs
+++ b/src/models/set/maximum_set_packing.rs
@@ -5,7 +5,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize, WeightElement};
+use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -145,6 +145,17 @@ where
 
     fn variant() -> Vec<(&'static str, &'static str)> {
         crate::variant_params![W]
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        let universe_size = self.sets().iter()
+            .flat_map(|s| s.iter())
+            .max()
+            .map_or(0, |&m| m + 1);
+        ProblemSize::new(vec![
+            ("num_sets", self.num_sets()),
+            ("universe_size", universe_size),
+        ])
     }
 }
 

--- a/src/models/set/minimum_set_covering.rs
+++ b/src/models/set/minimum_set_covering.rs
@@ -5,7 +5,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize, WeightElement};
+use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -158,6 +158,13 @@ where
 
     fn variant() -> Vec<(&'static str, &'static str)> {
         crate::variant_params![W]
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_sets", self.num_sets()),
+            ("universe_size", self.universe_size()),
+        ])
     }
 }
 

--- a/src/models/set/minimum_set_covering.rs
+++ b/src/models/set/minimum_set_covering.rs
@@ -5,7 +5,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize, WeightElement};
+use crate::types::{Direction, SolutionSize, WeightElement};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -160,11 +160,11 @@ where
         crate::variant_params![W]
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("num_sets", self.num_sets()),
-            ("universe_size", self.universe_size()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_sets", "universe_size"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.num_sets(), self.universe_size()]
     }
 }
 

--- a/src/models/specialized/biclique_cover.rs
+++ b/src/models/specialized/biclique_cover.rs
@@ -5,7 +5,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize};
+use crate::types::{Direction, ProblemSize, SolutionSize};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
@@ -115,6 +115,16 @@ impl BicliqueCover {
             edges,
             k,
         }
+    }
+
+    /// Get the left partition size.
+    pub fn left_size(&self) -> usize {
+        self.left_size
+    }
+
+    /// Get the right partition size.
+    pub fn right_size(&self) -> usize {
+        self.right_size
     }
 
     /// Get the number of vertices.
@@ -227,6 +237,15 @@ impl Problem for BicliqueCover {
 
     fn variant() -> Vec<(&'static str, &'static str)> {
         crate::variant_params![]
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("left_size", self.left_size()),
+            ("right_size", self.right_size()),
+            ("num_edges", self.num_edges()),
+            ("rank", self.k()),
+        ])
     }
 }
 

--- a/src/models/specialized/biclique_cover.rs
+++ b/src/models/specialized/biclique_cover.rs
@@ -4,8 +4,9 @@
 //! (complete bipartite subgraphs) needed to cover all edges of a bipartite graph.
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
+use crate::topology::BipartiteGraph;
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize};
+use crate::types::{Direction, SolutionSize};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
@@ -32,11 +33,13 @@ inventory::submit! {
 ///
 /// ```
 /// use problemreductions::models::specialized::BicliqueCover;
+/// use problemreductions::topology::BipartiteGraph;
 /// use problemreductions::{Problem, Solver, BruteForce};
 ///
-/// // Bipartite graph: L = {0, 1}, R = {2, 3}
-/// // Edges: (0,2), (0,3), (1,2)
-/// let problem = BicliqueCover::new(2, 2, vec![(0, 2), (0, 3), (1, 2)], 2);
+/// // Bipartite graph: L = {0, 1}, R = {0, 1}
+/// // Edges: (0,0), (0,1), (1,0) in bipartite-local coordinates
+/// let graph = BipartiteGraph::new(2, 2, vec![(0, 0), (0, 1), (1, 0)]);
+/// let problem = BicliqueCover::new(graph, 2);
 ///
 /// let solver = BruteForce::new();
 /// let solutions = solver.find_all_best(&problem);
@@ -48,13 +51,8 @@ inventory::submit! {
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BicliqueCover {
-    /// Number of vertices in the left partition.
-    left_size: usize,
-    /// Number of vertices in the right partition.
-    right_size: usize,
-    /// Edges as (left_vertex, right_vertex) pairs.
-    /// Left vertices are 0..left_size, right are left_size..left_size+right_size.
-    edges: Vec<(usize, usize)>,
+    /// The bipartite graph.
+    graph: BipartiteGraph,
     /// Number of bicliques to use.
     k: usize,
 }
@@ -63,34 +61,10 @@ impl BicliqueCover {
     /// Create a new Biclique Cover problem.
     ///
     /// # Arguments
-    /// * `left_size` - Number of vertices in left partition (0 to left_size-1)
-    /// * `right_size` - Number of vertices in right partition (left_size to left_size+right_size-1)
-    /// * `edges` - Edges as (left, right) pairs
+    /// * `graph` - The bipartite graph
     /// * `k` - Number of bicliques
-    pub fn new(left_size: usize, right_size: usize, edges: Vec<(usize, usize)>, k: usize) -> Self {
-        // Validate edges are between left and right partitions
-        for &(l, r) in &edges {
-            assert!(
-                l < left_size,
-                "Left vertex {} out of bounds (max {})",
-                l,
-                left_size - 1
-            );
-            assert!(
-                r >= left_size && r < left_size + right_size,
-                "Right vertex {} out of bounds (should be in {}..{})",
-                r,
-                left_size,
-                left_size + right_size
-            );
-        }
-
-        Self {
-            left_size,
-            right_size,
-            edges,
-            k,
-        }
+    pub fn new(graph: BipartiteGraph, k: usize) -> Self {
+        Self { graph, k }
     }
 
     /// Create from a bipartite adjacency matrix.
@@ -104,37 +78,40 @@ impl BicliqueCover {
         for (i, row) in matrix.iter().enumerate() {
             for (j, &val) in row.iter().enumerate() {
                 if val != 0 {
-                    edges.push((i, left_size + j));
+                    edges.push((i, j));
                 }
             }
         }
 
         Self {
-            left_size,
-            right_size,
-            edges,
+            graph: BipartiteGraph::new(left_size, right_size, edges),
             k,
         }
     }
 
+    /// Get the bipartite graph.
+    pub fn graph(&self) -> &BipartiteGraph {
+        &self.graph
+    }
+
     /// Get the left partition size.
     pub fn left_size(&self) -> usize {
-        self.left_size
+        self.graph.left_size()
     }
 
     /// Get the right partition size.
     pub fn right_size(&self) -> usize {
-        self.right_size
+        self.graph.right_size()
     }
 
     /// Get the number of vertices.
     pub fn num_vertices(&self) -> usize {
-        self.left_size + self.right_size
+        self.graph.left_size() + self.graph.right_size()
     }
 
     /// Get the number of edges.
     pub fn num_edges(&self) -> usize {
-        self.edges.len()
+        self.graph.left_edges().len()
     }
 
     /// Get k (number of bicliques).
@@ -152,6 +129,7 @@ impl BicliqueCover {
         config: &[usize],
     ) -> (Vec<HashSet<usize>>, Vec<HashSet<usize>>) {
         let n = self.num_vertices();
+        let left_size = self.graph.left_size();
         let mut left_bicliques: Vec<HashSet<usize>> = vec![HashSet::new(); self.k];
         let mut right_bicliques: Vec<HashSet<usize>> = vec![HashSet::new(); self.k];
 
@@ -159,7 +137,7 @@ impl BicliqueCover {
             for b in 0..self.k {
                 let idx = v * self.k + b;
                 if config.get(idx).copied().unwrap_or(0) == 1 {
-                    if v < self.left_size {
+                    if v < left_size {
                         left_bicliques[b].insert(v);
                     } else {
                         right_bicliques[b].insert(v);
@@ -172,6 +150,8 @@ impl BicliqueCover {
     }
 
     /// Check if an edge is covered by the bicliques.
+    ///
+    /// Takes edge endpoints in unified vertex space.
     fn is_edge_covered(&self, left: usize, right: usize, config: &[usize]) -> bool {
         let (left_bicliques, right_bicliques) = self.get_biclique_memberships(config);
 
@@ -186,14 +166,18 @@ impl BicliqueCover {
 
     /// Check if all edges are covered.
     pub fn is_valid_cover(&self, config: &[usize]) -> bool {
-        self.edges
+        use crate::topology::Graph;
+        self.graph
+            .edges()
             .iter()
             .all(|&(l, r)| self.is_edge_covered(l, r, config))
     }
 
     /// Count covered edges.
     pub fn count_covered_edges(&self, config: &[usize]) -> usize {
-        self.edges
+        use crate::topology::Graph;
+        self.graph
+            .edges()
             .iter()
             .filter(|&&(l, r)| self.is_edge_covered(l, r, config))
             .count()
@@ -239,13 +223,11 @@ impl Problem for BicliqueCover {
         crate::variant_params![]
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("left_size", self.left_size()),
-            ("right_size", self.right_size()),
-            ("num_edges", self.num_edges()),
-            ("rank", self.k()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["left_size", "right_size", "num_edges", "rank"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.left_size(), self.right_size(), self.num_edges(), self.k()]
     }
 }
 

--- a/src/models/specialized/bmf.rs
+++ b/src/models/specialized/bmf.rs
@@ -6,7 +6,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize};
+use crate::types::{Direction, SolutionSize};
 use serde::{Deserialize, Serialize};
 
 inventory::submit! {
@@ -209,12 +209,11 @@ impl Problem for BMF {
         crate::variant_params![]
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("m", self.rows()),
-            ("n", self.cols()),
-            ("rank", self.rank()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["m", "n", "rank"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.rows(), self.cols(), self.rank()]
     }
 }
 

--- a/src/models/specialized/bmf.rs
+++ b/src/models/specialized/bmf.rs
@@ -6,7 +6,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize};
+use crate::types::{Direction, ProblemSize, SolutionSize};
 use serde::{Deserialize, Serialize};
 
 inventory::submit! {
@@ -207,6 +207,14 @@ impl Problem for BMF {
 
     fn variant() -> Vec<(&'static str, &'static str)> {
         crate::variant_params![]
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("m", self.rows()),
+            ("n", self.cols()),
+            ("rank", self.rank()),
+        ])
     }
 }
 

--- a/src/models/specialized/circuit.rs
+++ b/src/models/specialized/circuit.rs
@@ -282,11 +282,11 @@ impl Problem for CircuitSAT {
         crate::variant_params![]
     }
 
-    fn problem_size(&self) -> crate::types::ProblemSize {
-        crate::types::ProblemSize::new(vec![
-            ("num_variables", self.num_variables()),
-            ("num_assignments", self.circuit().num_assignments()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_variables", "num_assignments"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.num_variables(), self.circuit().num_assignments()]
     }
 }
 

--- a/src/models/specialized/circuit.rs
+++ b/src/models/specialized/circuit.rs
@@ -281,6 +281,13 @@ impl Problem for CircuitSAT {
     fn variant() -> Vec<(&'static str, &'static str)> {
         crate::variant_params![]
     }
+
+    fn problem_size(&self) -> crate::types::ProblemSize {
+        crate::types::ProblemSize::new(vec![
+            ("num_variables", self.num_variables()),
+            ("num_assignments", self.circuit().num_assignments()),
+        ])
+    }
 }
 
 impl SatisfactionProblem for CircuitSAT {}

--- a/src/models/specialized/factoring.rs
+++ b/src/models/specialized/factoring.rs
@@ -5,7 +5,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize};
+use crate::types::{Direction, SolutionSize};
 use serde::{Deserialize, Serialize};
 
 inventory::submit! {
@@ -137,11 +137,11 @@ impl Problem for Factoring {
         crate::variant_params![]
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("num_bits_first", self.m()),
-            ("num_bits_second", self.n()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_bits_first", "num_bits_second"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.m(), self.n()]
     }
 }
 

--- a/src/models/specialized/factoring.rs
+++ b/src/models/specialized/factoring.rs
@@ -5,7 +5,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize};
+use crate::types::{Direction, ProblemSize, SolutionSize};
 use serde::{Deserialize, Serialize};
 
 inventory::submit! {
@@ -135,6 +135,13 @@ impl Problem for Factoring {
 
     fn variant() -> Vec<(&'static str, &'static str)> {
         crate::variant_params![]
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_bits_first", self.m()),
+            ("num_bits_second", self.n()),
+        ])
     }
 }
 

--- a/src/models/specialized/paintshop.rs
+++ b/src/models/specialized/paintshop.rs
@@ -7,7 +7,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, ProblemSize, SolutionSize};
+use crate::types::{Direction, SolutionSize};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
@@ -177,11 +177,11 @@ impl Problem for PaintShop {
         crate::variant_params![]
     }
 
-    fn problem_size(&self) -> ProblemSize {
-        ProblemSize::new(vec![
-            ("num_cars", self.num_cars()),
-            ("num_sequence", self.sequence_len()),
-        ])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_cars", "num_sequence"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.num_cars(), self.sequence_len()]
     }
 }
 

--- a/src/models/specialized/paintshop.rs
+++ b/src/models/specialized/paintshop.rs
@@ -7,7 +7,7 @@
 
 use crate::registry::{FieldInfo, ProblemSchemaEntry};
 use crate::traits::{OptimizationProblem, Problem};
-use crate::types::{Direction, SolutionSize};
+use crate::types::{Direction, ProblemSize, SolutionSize};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
@@ -175,6 +175,13 @@ impl Problem for PaintShop {
 
     fn variant() -> Vec<(&'static str, &'static str)> {
         crate::variant_params![]
+    }
+
+    fn problem_size(&self) -> ProblemSize {
+        ProblemSize::new(vec![
+            ("num_cars", self.num_cars()),
+            ("num_sequence", self.sequence_len()),
+        ])
     }
 }
 

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -1,6 +1,7 @@
 //! Polynomial representation for reduction overhead.
 
 use crate::types::ProblemSize;
+use std::collections::HashSet;
 use std::fmt;
 use std::ops::Add;
 
@@ -99,6 +100,14 @@ impl Polynomial {
 
     pub fn evaluate(&self, size: &ProblemSize) -> f64 {
         self.terms.iter().map(|m| m.evaluate(size)).sum()
+    }
+
+    /// Collect all variable names referenced by this polynomial.
+    pub fn variable_names(&self) -> HashSet<&'static str> {
+        self.terms
+            .iter()
+            .flat_map(|m| m.variables.iter().map(|(name, _)| *name))
+            .collect()
     }
 }
 

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -1,7 +1,7 @@
 //! Polynomial representation for reduction overhead.
 
 use crate::types::ProblemSize;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::ops::Add;
 
@@ -49,6 +49,39 @@ impl Monomial {
             })
             .product();
         self.coefficient * var_product
+    }
+
+    /// Multiply two monomials.
+    pub fn mul(&self, other: &Monomial) -> Monomial {
+        let mut variables = self.variables.clone();
+        variables.extend_from_slice(&other.variables);
+        Monomial {
+            coefficient: self.coefficient * other.coefficient,
+            variables,
+        }
+    }
+
+    /// Normalize: sort variables by name, merge duplicate entries.
+    pub fn normalize(&mut self) {
+        self.variables.sort_by_key(|(name, _)| *name);
+        let mut merged: Vec<(&'static str, u8)> = Vec::new();
+        for &(name, exp) in &self.variables {
+            if let Some(last) = merged.last_mut() {
+                if last.0 == name {
+                    last.1 += exp;
+                    continue;
+                }
+            }
+            merged.push((name, exp));
+        }
+        // Remove zero-exponent variables
+        merged.retain(|&(_, exp)| exp > 0);
+        self.variables = merged;
+    }
+
+    /// Variable signature for like-term comparison (after normalization).
+    fn var_signature(&self) -> &[(&'static str, u8)] {
+        &self.variables
     }
 }
 
@@ -108,6 +141,87 @@ impl Polynomial {
             .iter()
             .flat_map(|m| m.variables.iter().map(|(name, _)| *name))
             .collect()
+    }
+
+    /// Multiply two polynomials.
+    pub fn mul(&self, other: &Polynomial) -> Polynomial {
+        let mut terms = Vec::new();
+        for a in &self.terms {
+            for b in &other.terms {
+                terms.push(a.mul(b));
+            }
+        }
+        let mut result = Polynomial { terms };
+        result.normalize();
+        result
+    }
+
+    /// Raise to a non-negative integer power.
+    pub fn pow(&self, n: u8) -> Polynomial {
+        match n {
+            0 => Polynomial::constant(1.0),
+            1 => self.clone(),
+            _ => {
+                let mut result = self.clone();
+                for _ in 1..n {
+                    result = result.mul(self);
+                }
+                result
+            }
+        }
+    }
+
+    /// Substitute variables with polynomials.
+    ///
+    /// Each variable in the polynomial is replaced by the corresponding
+    /// polynomial from the mapping. Variables not in the mapping are left as-is.
+    pub fn substitute(&self, mapping: &HashMap<&str, &Polynomial>) -> Polynomial {
+        let mut result = Polynomial::zero();
+        for mono in &self.terms {
+            // Start with the coefficient
+            let mut term_poly = Polynomial::constant(mono.coefficient);
+            // Multiply by each variable's substitution raised to its exponent
+            for &(name, exp) in &mono.variables {
+                let var_poly = if let Some(&replacement) = mapping.get(name) {
+                    replacement.pow(exp)
+                } else {
+                    Polynomial::var_pow(name, exp)
+                };
+                term_poly = term_poly.mul(&var_poly);
+            }
+            result = result + term_poly;
+        }
+        result.normalize();
+        result
+    }
+
+    /// Normalize: normalize all monomials, then combine like terms.
+    pub fn normalize(&mut self) {
+        for term in &mut self.terms {
+            term.normalize();
+        }
+        // Combine like terms
+        let mut combined: Vec<Monomial> = Vec::new();
+        for term in &self.terms {
+            if let Some(existing) = combined
+                .iter_mut()
+                .find(|m| m.var_signature() == term.var_signature())
+            {
+                existing.coefficient += term.coefficient;
+            } else {
+                combined.push(term.clone());
+            }
+        }
+        // Remove zero-coefficient terms
+        combined.retain(|m| m.coefficient.abs() > 1e-15);
+        self.terms = combined;
+    }
+
+    /// Return a normalized copy.
+    pub fn normalized(&self) -> Polynomial {
+        let mut p = self.clone();
+        p.normalize();
+        p
     }
 }
 

--- a/src/rules/coloring_ilp.rs
+++ b/src/rules/coloring_ilp.rs
@@ -125,8 +125,8 @@ fn reduce_kcoloring_to_ilp<K: KValue, G: Graph>(
 #[reduction(
     overhead = {
         ReductionOverhead::new(vec![
-            ("num_vars", poly!(num_vertices * num_colors)),
-            ("num_constraints", poly!(num_vertices) + poly!(num_edges * num_colors)),
+            ("num_vars", poly!(num_vertices ^ 2)),
+            ("num_constraints", poly!(num_vertices) + poly!(num_vertices * num_edges)),
         ])
     }
 )]

--- a/src/rules/coloring_qubo.rs
+++ b/src/rules/coloring_qubo.rs
@@ -107,7 +107,7 @@ fn reduce_kcoloring_to_qubo<K: KValue>(
 
 // Register only the KN variant in the reduction graph
 #[reduction(
-    overhead = { ReductionOverhead::new(vec![("num_vars", poly!(num_vertices * num_colors))]) }
+    overhead = { ReductionOverhead::new(vec![("num_vars", poly!(num_vertices ^ 2))]) }
 )]
 impl ReduceTo<QUBO<f64>> for KColoring<KN, SimpleGraph> {
     type Result = ReductionKColoringToQUBO<KN>;

--- a/src/rules/factoring_circuit.rs
+++ b/src/rules/factoring_circuit.rs
@@ -178,7 +178,8 @@ fn build_multiplier_cell(
 
 #[reduction(overhead = {
     ReductionOverhead::new(vec![
-        ("num_gates", poly!(num_bits_first * num_bits_second)),
+        ("num_variables", poly!(num_bits_first * num_bits_second)),
+        ("num_assignments", poly!(num_bits_first * num_bits_second)),
     ])
 })]
 impl ReduceTo<CircuitSAT> for Factoring {

--- a/src/rules/graph.rs
+++ b/src/rules/graph.rs
@@ -276,11 +276,7 @@ impl ReductionGraph {
     }
 
     /// Look up a variant node by name and variant map.
-    fn lookup_node(
-        &self,
-        name: &str,
-        variant: &BTreeMap<String, String>,
-    ) -> Option<NodeIndex> {
+    fn lookup_node(&self, name: &str, variant: &BTreeMap<String, String>) -> Option<NodeIndex> {
         let nodes = self.name_to_nodes.get(name)?;
         nodes
             .iter()
@@ -305,8 +301,11 @@ impl ReductionGraph {
 
         // Validate: when input_size is non-empty, check outgoing edges
         if !input_size.components.is_empty() {
-            let size_names: std::collections::HashSet<&str> =
-                input_size.components.iter().map(|(k, _)| k.as_str()).collect();
+            let size_names: std::collections::HashSet<&str> = input_size
+                .components
+                .iter()
+                .map(|(k, _)| k.as_str())
+                .collect();
             for edge_ref in self.graph.edges(src) {
                 let missing: Vec<_> = edge_ref
                     .weight()
@@ -425,11 +424,12 @@ impl ReductionGraph {
             None => return vec![],
         };
 
-        let paths: Vec<Vec<NodeIndex>> =
-            all_simple_paths::<Vec<NodeIndex>, _, std::hash::RandomState>(
-                &self.graph, src, dst, 0, None,
-            )
-            .collect();
+        let paths: Vec<Vec<NodeIndex>> = all_simple_paths::<
+            Vec<NodeIndex>,
+            _,
+            std::hash::RandomState,
+        >(&self.graph, src, dst, 0, None)
+        .collect();
 
         paths
             .iter()

--- a/src/rules/kcoloring_casts.rs
+++ b/src/rules/kcoloring_casts.rs
@@ -8,6 +8,6 @@ use crate::variant::{K3, KN};
 impl_variant_reduction!(
     KColoring,
     <K3, SimpleGraph> => <KN, SimpleGraph>,
-    fields: [num_vertices, num_colors],
+    fields: [num_vertices, num_edges],
     |src| KColoring::with_k(src.graph().clone(), src.num_colors())
 );

--- a/src/rules/maximumindependentset_maximumsetpacking.rs
+++ b/src/rules/maximumindependentset_maximumsetpacking.rs
@@ -40,7 +40,7 @@ where
     overhead = {
         ReductionOverhead::new(vec![
             ("num_sets", poly!(num_vertices)),
-            ("num_elements", poly!(num_vertices)),
+            ("universe_size", poly!(num_vertices)),
         ])
     }
 )]

--- a/src/rules/maximumindependentset_maximumsetpacking.rs
+++ b/src/rules/maximumindependentset_maximumsetpacking.rs
@@ -114,7 +114,8 @@ impl ReduceTo<MaximumIndependentSet<SimpleGraph, i32>> for MaximumSetPacking<i32
             }
         }
 
-        let target = MaximumIndependentSet::new(SimpleGraph::new(n, edges), self.weights_ref().clone());
+        let target =
+            MaximumIndependentSet::new(SimpleGraph::new(n, edges), self.weights_ref().clone());
 
         ReductionSPToIS { target }
     }

--- a/src/rules/maximummatching_maximumsetpacking.rs
+++ b/src/rules/maximummatching_maximumsetpacking.rs
@@ -41,7 +41,7 @@ where
     overhead = {
         ReductionOverhead::new(vec![
             ("num_sets", poly!(num_edges)),
-            ("num_elements", poly!(num_vertices)),
+            ("universe_size", poly!(num_vertices)),
         ])
     }
 )]

--- a/src/rules/maximumsetpacking_casts.rs
+++ b/src/rules/maximumsetpacking_casts.rs
@@ -7,7 +7,7 @@ use crate::variant::CastToParent;
 impl_variant_reduction!(
     MaximumSetPacking,
     <i32> => <f64>,
-    fields: [num_sets, num_elements],
+    fields: [num_sets, universe_size],
     |src| MaximumSetPacking::with_weights(
         src.sets().to_vec(),
         src.weights_ref().iter().map(|w| w.cast_to_parent()).collect())

--- a/src/rules/minimumvertexcover_minimumsetcovering.rs
+++ b/src/rules/minimumvertexcover_minimumsetcovering.rs
@@ -40,7 +40,7 @@ where
     overhead = {
         ReductionOverhead::new(vec![
             ("num_sets", poly!(num_vertices)),
-            ("num_elements", poly!(num_edges)),
+            ("universe_size", poly!(num_edges)),
         ])
     }
 )]

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -68,6 +68,8 @@ pub use graph::{
     ChainedReduction, EdgeJson, ExecutablePath, NodeJson, ReductionGraph, ReductionGraphJson,
     ReductionPath, ReductionStep,
 };
+#[cfg(test)]
+pub(crate) use graph::validate_overhead_variables;
 pub use ksatisfiability_qubo::{Reduction3SATToQUBO, ReductionKSatToQUBO};
 pub use maximumindependentset_gridgraph::{ReductionISSimpleToGrid, ReductionISUnitDiskToGrid};
 pub use maximumindependentset_maximumsetpacking::{ReductionISToSP, ReductionSPToIS};

--- a/src/rules/registry.rs
+++ b/src/rules/registry.rs
@@ -4,6 +4,7 @@ use crate::polynomial::Polynomial;
 use crate::rules::traits::DynReductionResult;
 use crate::types::ProblemSize;
 use std::any::Any;
+use std::collections::HashSet;
 
 /// Overhead specification for a reduction.
 #[derive(Clone, Debug, Default, serde::Serialize)]
@@ -39,6 +40,14 @@ impl ReductionOverhead {
             .map(|(name, poly)| (*name, poly.evaluate(input).round() as usize))
             .collect();
         ProblemSize::new(fields)
+    }
+
+    /// Collect all input variable names referenced by the overhead polynomials.
+    pub fn input_variable_names(&self) -> HashSet<&'static str> {
+        self.output_size
+            .iter()
+            .flat_map(|(_, poly)| poly.variable_names())
+            .collect()
     }
 }
 

--- a/src/rules/registry.rs
+++ b/src/rules/registry.rs
@@ -49,6 +49,39 @@ impl ReductionOverhead {
             .flat_map(|(_, poly)| poly.variable_names())
             .collect()
     }
+
+    /// Compose two overheads: substitute self's output into `next`'s input.
+    ///
+    /// Returns a new overhead whose polynomials map from self's input variables
+    /// directly to `next`'s output variables.
+    pub fn compose(&self, next: &ReductionOverhead) -> ReductionOverhead {
+        use std::collections::HashMap;
+
+        // Build substitution map: output field name → output polynomial
+        let mapping: HashMap<&str, &Polynomial> = self
+            .output_size
+            .iter()
+            .map(|(name, poly)| (*name, poly))
+            .collect();
+
+        let composed = next
+            .output_size
+            .iter()
+            .map(|(name, poly)| (*name, poly.substitute(&mapping)))
+            .collect();
+
+        ReductionOverhead {
+            output_size: composed,
+        }
+    }
+
+    /// Get the polynomial for a named output field.
+    pub fn get(&self, name: &str) -> Option<&Polynomial> {
+        self.output_size
+            .iter()
+            .find(|(n, _)| *n == name)
+            .map(|(_, p)| p)
+    }
 }
 
 /// A registered reduction entry for static inventory registration.
@@ -66,6 +99,10 @@ pub struct ReductionEntry {
     pub overhead_fn: fn() -> ReductionOverhead,
     /// Module path where the reduction is defined (from `module_path!()`).
     pub module_path: &'static str,
+    /// Type-level problem size field names for the source problem.
+    pub source_size_names_fn: fn() -> &'static [&'static str],
+    /// Type-level problem size field names for the target problem.
+    pub target_size_names_fn: fn() -> &'static [&'static str],
     /// Type-erased reduction executor.
     /// Takes a `&dyn Any` (must be `&SourceType`), calls `ReduceTo::reduce_to()`,
     /// and returns the result as a boxed `DynReductionResult`.

--- a/src/rules/sat_circuitsat.rs
+++ b/src/rules/sat_circuitsat.rs
@@ -38,7 +38,8 @@ impl ReductionResult for ReductionSATToCircuit {
 #[reduction(
     overhead = {
         ReductionOverhead::new(vec![
-            ("num_variables", poly!(num_variables) + poly!(num_clauses) + poly!(1)),
+            ("num_variables", poly!(num_vars) + poly!(num_clauses) + poly!(1)),
+            ("num_assignments", poly!(num_clauses) + poly!(2)),
         ])
     }
 )]

--- a/src/rules/sat_coloring.rs
+++ b/src/rules/sat_coloring.rs
@@ -301,7 +301,8 @@ impl ReductionSATToColoring {
         ReductionOverhead::new(vec![
             // 2*num_vars + 3 (base) + 5*(num_literals - num_clauses) (OR gadgets)
             ("num_vertices", poly!(2 * num_vars) + poly!(5 * num_literals) + poly!(num_clauses).scale(-5.0) + poly!(3)),
-            ("num_edges", poly!(2 * num_vars) + poly!(5 * num_literals) + poly!(num_clauses).scale(-5.0) + poly!(3)),
+            // 3 (triangle) + 3*num_vars + 11*(num_literals - num_clauses) (OR gadgets) + 2*num_clauses (set_true)
+            ("num_edges", poly!(3 * num_vars) + poly!(11 * num_literals) + poly!(num_clauses).scale(-9.0) + poly!(3)),
         ])
     }
 )]

--- a/src/rules/sat_coloring.rs
+++ b/src/rules/sat_coloring.rs
@@ -301,7 +301,7 @@ impl ReductionSATToColoring {
         ReductionOverhead::new(vec![
             // 2*num_vars + 3 (base) + 5*(num_literals - num_clauses) (OR gadgets)
             ("num_vertices", poly!(2 * num_vars) + poly!(5 * num_literals) + poly!(num_clauses).scale(-5.0) + poly!(3)),
-            ("num_colors", poly!(3)),
+            ("num_edges", poly!(2 * num_vars) + poly!(5 * num_literals) + poly!(num_clauses).scale(-5.0) + poly!(3)),
         ])
     }
 )]

--- a/src/rules/sat_ksat.rs
+++ b/src/rules/sat_ksat.rs
@@ -190,6 +190,7 @@ macro_rules! impl_ksat_to_sat {
                                                             ReductionOverhead::new(vec![
                                                                 ("num_clauses", poly!(num_clauses)),
                                                                 ("num_vars", poly!(num_vars)),
+                                                                ("num_literals", poly!(num_literals)),
                                                             ])
                                                         })]
         impl ReduceTo<Satisfiability> for KSatisfiability<$ktype> {

--- a/src/rules/sat_maximumindependentset.rs
+++ b/src/rules/sat_maximumindependentset.rs
@@ -155,7 +155,10 @@ impl ReduceTo<MaximumIndependentSet<SimpleGraph, i32>> for Satisfiability {
             }
         }
 
-        let target = MaximumIndependentSet::new(SimpleGraph::new(vertex_count, edges), vec![1i32; vertex_count]);
+        let target = MaximumIndependentSet::new(
+            SimpleGraph::new(vertex_count, edges),
+            vec![1i32; vertex_count],
+        );
 
         ReductionSATToIS {
             target,

--- a/src/rules/sat_minimumdominatingset.rs
+++ b/src/rules/sat_minimumdominatingset.rs
@@ -166,7 +166,10 @@ impl ReduceTo<MinimumDominatingSet<SimpleGraph, i32>> for Satisfiability {
             }
         }
 
-        let target = MinimumDominatingSet::new(SimpleGraph::new(num_vertices, edges), vec![1i32; num_vertices]);
+        let target = MinimumDominatingSet::new(
+            SimpleGraph::new(num_vertices, edges),
+            vec![1i32; num_vertices],
+        );
 
         ReductionSATToDS {
             target,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -22,6 +22,8 @@ pub trait Problem: Clone {
     /// Used for generating variant IDs in the reduction graph schema.
     /// Returns pairs like `[("graph", "SimpleGraph"), ("weight", "i32")]`.
     fn variant() -> Vec<(&'static str, &'static str)>;
+    /// Named size components for overhead estimation in reduction path-finding.
+    fn problem_size(&self) -> crate::types::ProblemSize;
 }
 
 /// Extension for problems with a numeric objective to optimize.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -22,8 +22,18 @@ pub trait Problem: Clone {
     /// Used for generating variant IDs in the reduction graph schema.
     /// Returns pairs like `[("graph", "SimpleGraph"), ("weight", "i32")]`.
     fn variant() -> Vec<(&'static str, &'static str)>;
-    /// Named size components for overhead estimation in reduction path-finding.
-    fn problem_size(&self) -> crate::types::ProblemSize;
+    /// Type-level: fixed field names for this problem type's size metrics.
+    ///
+    /// Every instance of this problem type uses the same set of field names,
+    /// so this is a static method.
+    fn problem_size_names() -> &'static [&'static str];
+    /// Instance-level: values for each size field (same order as `problem_size_names()`).
+    fn problem_size_values(&self) -> Vec<usize>;
+}
+
+/// Combine type-level names and instance-level values into a [`ProblemSize`].
+pub fn problem_size<P: Problem>(p: &P) -> crate::types::ProblemSize {
+    crate::types::ProblemSize::from_names_values(P::problem_size_names(), &p.problem_size_values())
 }
 
 /// Extension for problems with a numeric objective to optimize.

--- a/src/types.rs
+++ b/src/types.rs
@@ -200,6 +200,27 @@ impl ProblemSize {
         }
     }
 
+    /// Create from separate names and values arrays.
+    ///
+    /// This is the primary constructor used by the `problem_size()` free function,
+    /// combining type-level names with instance-level values.
+    pub fn from_names_values(names: &[&str], values: &[usize]) -> Self {
+        debug_assert_eq!(
+            names.len(),
+            values.len(),
+            "ProblemSize: names ({}) and values ({}) length mismatch",
+            names.len(),
+            values.len()
+        );
+        Self {
+            components: names
+                .iter()
+                .zip(values.iter())
+                .map(|(k, v)| (k.to_string(), *v))
+                .collect(),
+        }
+    }
+
     /// Get a size component by name.
     pub fn get(&self, name: &str) -> Option<usize> {
         self.components

--- a/src/types.rs
+++ b/src/types.rs
@@ -205,7 +205,7 @@ impl ProblemSize {
     /// This is the primary constructor used by the `problem_size()` free function,
     /// combining type-level names with instance-level values.
     pub fn from_names_values(names: &[&str], values: &[usize]) -> Self {
-        debug_assert_eq!(
+        assert_eq!(
             names.len(),
             values.len(),
             "ProblemSize: names ({}) and values ({}) length mismatch",

--- a/src/unit_tests/graph_models.rs
+++ b/src/unit_tests/graph_models.rs
@@ -22,8 +22,10 @@ mod maximum_independent_set {
 
     #[test]
     fn test_creation() {
-        let problem =
-            MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+        let problem = MaximumIndependentSet::new(
+            SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+            vec![1i32; 4],
+        );
         assert_eq!(problem.graph().num_vertices(), 4);
         assert_eq!(problem.graph().num_edges(), 3);
         assert_eq!(problem.num_variables(), 4);
@@ -45,7 +47,8 @@ mod maximum_independent_set {
 
     #[test]
     fn test_has_edge() {
-        let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+        let problem =
+            MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
         assert!(problem.graph().has_edge(0, 1));
         assert!(problem.graph().has_edge(1, 0)); // Undirected
         assert!(problem.graph().has_edge(1, 2));
@@ -54,7 +57,8 @@ mod maximum_independent_set {
 
     #[test]
     fn test_evaluate_valid() {
-        let problem = MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (2, 3)]), vec![1i32; 4]);
+        let problem =
+            MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (2, 3)]), vec![1i32; 4]);
 
         // Valid: select 0 and 2 (not adjacent)
         assert_eq!(problem.evaluate(&[1, 0, 1, 0]), SolutionSize::Valid(2));
@@ -65,7 +69,8 @@ mod maximum_independent_set {
 
     #[test]
     fn test_evaluate_invalid() {
-        let problem = MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (2, 3)]), vec![1i32; 4]);
+        let problem =
+            MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (2, 3)]), vec![1i32; 4]);
 
         // Invalid: 0 and 1 are adjacent - returns Invalid
         assert_eq!(problem.evaluate(&[1, 1, 0, 0]), SolutionSize::Invalid);
@@ -76,14 +81,16 @@ mod maximum_independent_set {
 
     #[test]
     fn test_evaluate_empty() {
-        let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+        let problem =
+            MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
         // Empty selection is valid with size 0
         assert_eq!(problem.evaluate(&[0, 0, 0]), SolutionSize::Valid(0));
     }
 
     #[test]
     fn test_evaluate_weighted() {
-        let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![10, 20, 30]);
+        let problem =
+            MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![10, 20, 30]);
 
         // Select vertex 2 (weight 30)
         assert_eq!(problem.evaluate(&[0, 0, 1]), SolutionSize::Valid(30));
@@ -95,8 +102,10 @@ mod maximum_independent_set {
     #[test]
     fn test_brute_force_triangle() {
         // Triangle graph: maximum IS has size 1
-        let problem =
-            MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+        let problem = MaximumIndependentSet::new(
+            SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+            vec![1i32; 3],
+        );
         let solver = BruteForce::new();
 
         let solutions = solver.find_all_best(&problem);
@@ -110,8 +119,10 @@ mod maximum_independent_set {
     #[test]
     fn test_brute_force_path() {
         // Path graph 0-1-2-3: maximum IS = {0,2} or {1,3} or {0,3}
-        let problem =
-            MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+        let problem = MaximumIndependentSet::new(
+            SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+            vec![1i32; 4],
+        );
         let solver = BruteForce::new();
 
         let solutions = solver.find_all_best(&problem);
@@ -127,7 +138,8 @@ mod maximum_independent_set {
     #[test]
     fn test_brute_force_weighted() {
         // Graph with weights: vertex 1 has high weight but is connected to both 0 and 2
-        let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1, 100, 1]);
+        let problem =
+            MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1, 100, 1]);
         let solver = BruteForce::new();
 
         let solutions = solver.find_all_best(&problem);
@@ -168,7 +180,8 @@ mod maximum_independent_set {
 
     #[test]
     fn test_edges() {
-        let problem = MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (2, 3)]), vec![1i32; 4]);
+        let problem =
+            MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (2, 3)]), vec![1i32; 4]);
         let edges = problem.graph().edges();
         assert_eq!(edges.len(), 2);
         assert!(edges.contains(&(0, 1)) || edges.contains(&(1, 0)));
@@ -177,10 +190,8 @@ mod maximum_independent_set {
 
     #[test]
     fn test_with_custom_weights() {
-        let problem = MaximumIndependentSet::new(
-            SimpleGraph::new(3, vec![(0, 1)]),
-            vec![5, 10, 15],
-        );
+        let problem =
+            MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![5, 10, 15]);
         assert_eq!(problem.weights().to_vec(), vec![5, 10, 15]);
     }
 
@@ -197,7 +208,8 @@ mod maximum_independent_set {
 
     #[test]
     fn test_validity_via_evaluate() {
-        let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+        let problem =
+            MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
 
         // Valid IS configurations return is_valid() == true
         assert!(problem.evaluate(&[1, 0, 1]).is_valid());
@@ -217,7 +229,10 @@ mod minimum_vertex_cover {
 
     #[test]
     fn test_creation() {
-        let problem = MinimumVertexCover::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+        let problem = MinimumVertexCover::new(
+            SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+            vec![1i32; 4],
+        );
         assert_eq!(problem.graph().num_vertices(), 4);
         assert_eq!(problem.graph().num_edges(), 3);
         assert_eq!(problem.num_variables(), 4);
@@ -232,7 +247,8 @@ mod minimum_vertex_cover {
 
     #[test]
     fn test_evaluate_valid() {
-        let problem = MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+        let problem =
+            MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
 
         // Valid: select vertex 1 (covers both edges)
         assert_eq!(problem.evaluate(&[0, 1, 0]), SolutionSize::Valid(1));
@@ -243,7 +259,8 @@ mod minimum_vertex_cover {
 
     #[test]
     fn test_evaluate_invalid() {
-        let problem = MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+        let problem =
+            MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
 
         // Invalid: no vertex selected - returns Invalid for minimization
         assert_eq!(problem.evaluate(&[0, 0, 0]), SolutionSize::Invalid);
@@ -255,7 +272,8 @@ mod minimum_vertex_cover {
     #[test]
     fn test_brute_force_path() {
         // Path graph 0-1-2: minimum vertex cover is {1}
-        let problem = MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+        let problem =
+            MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
         let solver = BruteForce::new();
 
         let solutions = solver.find_all_best(&problem);
@@ -266,7 +284,10 @@ mod minimum_vertex_cover {
     #[test]
     fn test_brute_force_triangle() {
         // Triangle: minimum vertex cover has size 2
-        let problem = MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+        let problem = MinimumVertexCover::new(
+            SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+            vec![1i32; 3],
+        );
         let solver = BruteForce::new();
 
         let solutions = solver.find_all_best(&problem);
@@ -282,7 +303,8 @@ mod minimum_vertex_cover {
     #[test]
     fn test_brute_force_weighted() {
         // Weighted: prefer selecting low-weight vertices
-        let problem = MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![100, 1, 100]);
+        let problem =
+            MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![100, 1, 100]);
         let solver = BruteForce::new();
 
         let solutions = solver.find_all_best(&problem);
@@ -340,7 +362,8 @@ mod minimum_vertex_cover {
 
     #[test]
     fn test_validity_via_evaluate() {
-        let problem = MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+        let problem =
+            MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
 
         // Valid cover configurations return is_valid() == true
         assert!(problem.evaluate(&[0, 1, 0]).is_valid());
@@ -354,7 +377,8 @@ mod minimum_vertex_cover {
     fn test_complement_relationship() {
         // For a graph, if S is an independent set, then V\S is a vertex cover
         let edges = vec![(0, 1), (1, 2), (2, 3)];
-        let is_problem = MaximumIndependentSet::new(SimpleGraph::new(4, edges.clone()), vec![1i32; 4]);
+        let is_problem =
+            MaximumIndependentSet::new(SimpleGraph::new(4, edges.clone()), vec![1i32; 4]);
         let vc_problem = MinimumVertexCover::new(SimpleGraph::new(4, edges), vec![1i32; 4]);
 
         let solver = BruteForce::new();

--- a/src/unit_tests/io.rs
+++ b/src/unit_tests/io.rs
@@ -6,7 +6,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
 fn test_to_json() {
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+    let problem =
+        MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
     let json = to_json(&problem);
     assert!(json.is_ok());
     let json = json.unwrap();
@@ -15,7 +16,8 @@ fn test_to_json() {
 
 #[test]
 fn test_from_json() {
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+    let problem =
+        MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
     let json = to_json(&problem).unwrap();
     let restored: MaximumIndependentSet<SimpleGraph, i32> = from_json(&json).unwrap();
     assert_eq!(restored.graph().num_vertices(), 3);
@@ -33,7 +35,10 @@ fn test_json_compact() {
 
 #[test]
 fn test_file_roundtrip() {
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+    let problem = MaximumIndependentSet::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1i32; 4],
+    );
     let ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()

--- a/src/unit_tests/models/graph/kcoloring.rs
+++ b/src/unit_tests/models/graph/kcoloring.rs
@@ -119,8 +119,10 @@ fn test_complete_graph_k4() {
     use crate::traits::Problem;
 
     // K4 needs 4 colors
-    let problem =
-        KColoring::<K4, _>::new(SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]));
+    let problem = KColoring::<K4, _>::new(SimpleGraph::new(
+        4,
+        vec![(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)],
+    ));
     let solver = BruteForce::new();
 
     let solutions = solver.find_all_satisfying(&problem);

--- a/src/unit_tests/models/graph/max_cut.rs
+++ b/src/unit_tests/models/graph/max_cut.rs
@@ -7,7 +7,10 @@ include!("../../jl_helpers.rs");
 fn test_maxcut_creation() {
     use crate::traits::Problem;
 
-    let problem = MaxCut::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1, 2, 3]);
+    let problem = MaxCut::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1, 2, 3],
+    );
     assert_eq!(problem.graph().num_vertices(), 4);
     assert_eq!(problem.graph().num_edges(), 3);
     assert_eq!(problem.dims(), vec![2, 2, 2, 2]);

--- a/src/unit_tests/models/graph/maximal_is.rs
+++ b/src/unit_tests/models/graph/maximal_is.rs
@@ -5,7 +5,10 @@ include!("../../jl_helpers.rs");
 
 #[test]
 fn test_maximal_is_creation() {
-    let problem = MaximalIS::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+    let problem = MaximalIS::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1i32; 4],
+    );
     assert_eq!(problem.graph().num_vertices(), 4);
     assert_eq!(problem.graph().num_edges(), 3);
 }
@@ -57,10 +60,7 @@ fn test_is_maximal_independent_set_function() {
 
     assert!(is_maximal_independent_set(&graph, &[true, false, true]));
     assert!(is_maximal_independent_set(&graph, &[false, true, false]));
-    assert!(!is_maximal_independent_set(
-        &graph,
-        &[true, false, false]
-    )); // Can add 2
+    assert!(!is_maximal_independent_set(&graph, &[true, false, false])); // Can add 2
     assert!(!is_maximal_independent_set(&graph, &[true, true, false])); // Not independent
 }
 

--- a/src/unit_tests/models/graph/maximum_clique.rs
+++ b/src/unit_tests/models/graph/maximum_clique.rs
@@ -7,7 +7,10 @@ use crate::types::SolutionSize;
 fn test_clique_creation() {
     use crate::traits::Problem;
 
-    let problem = MaximumClique::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+    let problem = MaximumClique::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1i32; 4],
+    );
     assert_eq!(problem.graph().num_vertices(), 4);
     assert_eq!(problem.graph().num_edges(), 3);
     assert_eq!(problem.dims(), vec![2, 2, 2, 2]);
@@ -41,7 +44,10 @@ fn test_evaluate_valid() {
     use crate::traits::Problem;
 
     // Complete graph K3 (triangle)
-    let problem = MaximumClique::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+    let problem = MaximumClique::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![1i32; 3],
+    );
 
     // Valid: all three form a clique
     assert_eq!(problem.evaluate(&[1, 1, 1]), SolutionSize::Valid(3));
@@ -92,7 +98,10 @@ fn test_weighted_solution() {
 #[test]
 fn test_brute_force_triangle() {
     // Triangle graph (K3): max clique is all 3 vertices
-    let problem = MaximumClique::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+    let problem = MaximumClique::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![1i32; 3],
+    );
     let solver = BruteForce::new();
 
     let solutions = solver.find_all_best(&problem);
@@ -123,8 +132,7 @@ fn test_brute_force_weighted() {
     use crate::traits::Problem;
 
     // Path with weights: vertex 1 has high weight
-    let problem =
-        MaximumClique::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1, 100, 1]);
+    let problem = MaximumClique::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1, 100, 1]);
     let solver = BruteForce::new();
 
     let solutions = solver.find_all_best(&problem);
@@ -250,7 +258,10 @@ fn test_clique_problem() {
     use crate::types::Direction;
 
     // Triangle graph: all pairs connected
-    let p = MaximumClique::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+    let p = MaximumClique::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![1i32; 3],
+    );
     assert_eq!(p.dims(), vec![2, 2, 2]);
     // Valid clique: select all 3 vertices (triangle is a clique)
     assert_eq!(p.evaluate(&[1, 1, 1]), SolutionSize::Valid(3));

--- a/src/unit_tests/models/graph/maximum_independent_set.rs
+++ b/src/unit_tests/models/graph/maximum_independent_set.rs
@@ -7,7 +7,10 @@ include!("../../jl_helpers.rs");
 
 #[test]
 fn test_independent_set_creation() {
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+    let problem = MaximumIndependentSet::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1i32; 4],
+    );
     assert_eq!(problem.graph().num_vertices(), 4);
     assert_eq!(problem.graph().num_edges(), 3);
     assert_eq!(problem.dims().len(), 4);
@@ -15,8 +18,7 @@ fn test_independent_set_creation() {
 
 #[test]
 fn test_independent_set_with_weights() {
-    let problem =
-        MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![1, 2, 3]);
+    let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![1, 2, 3]);
     assert_eq!(problem.weights().to_vec(), vec![1, 2, 3]);
     assert!(problem.is_weighted());
 }
@@ -30,7 +32,8 @@ fn test_independent_set_unweighted() {
 
 #[test]
 fn test_has_edge() {
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+    let problem =
+        MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
     assert!(problem.graph().has_edge(0, 1));
     assert!(problem.graph().has_edge(1, 0)); // Undirected
     assert!(problem.graph().has_edge(1, 2));
@@ -69,7 +72,8 @@ fn test_direction() {
 
 #[test]
 fn test_edges() {
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (2, 3)]), vec![1i32; 4]);
+    let problem =
+        MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (2, 3)]), vec![1i32; 4]);
     let edges = problem.graph().edges();
     assert_eq!(edges.len(), 2);
     assert!(edges.contains(&(0, 1)) || edges.contains(&(1, 0)));
@@ -78,16 +82,14 @@ fn test_edges() {
 
 #[test]
 fn test_with_custom_weights() {
-    let problem =
-        MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![5, 10, 15]);
+    let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![5, 10, 15]);
     assert_eq!(problem.weights().to_vec(), vec![5, 10, 15]);
 }
 
 #[test]
 fn test_from_graph() {
     let graph = SimpleGraph::new(3, vec![(0, 1), (1, 2)]);
-    let problem =
-        MaximumIndependentSet::new(graph.clone(), vec![1, 2, 3]);
+    let problem = MaximumIndependentSet::new(graph.clone(), vec![1, 2, 3]);
     assert_eq!(problem.graph().num_vertices(), 3);
     assert_eq!(problem.weights().to_vec(), vec![1, 2, 3]);
 }
@@ -110,8 +112,7 @@ fn test_graph_accessor() {
 
 #[test]
 fn test_weights() {
-    let problem =
-        MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![5, 10, 15]);
+    let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![5, 10, 15]);
     assert_eq!(problem.weights(), &[5, 10, 15]);
 }
 

--- a/src/unit_tests/models/graph/maximum_matching.rs
+++ b/src/unit_tests/models/graph/maximum_matching.rs
@@ -7,8 +7,10 @@ include!("../../jl_helpers.rs");
 
 #[test]
 fn test_matching_creation() {
-    let problem =
-        MaximumMatching::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1, 2, 3]);
+    let problem = MaximumMatching::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1, 2, 3],
+    );
     assert_eq!(problem.graph().num_vertices(), 4);
     assert_eq!(problem.graph().num_edges(), 3);
     assert_eq!(problem.num_variables(), 3);
@@ -16,7 +18,8 @@ fn test_matching_creation() {
 
 #[test]
 fn test_matching_unit_weights() {
-    let problem = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(3, vec![(0, 1), (1, 2)]));
+    let problem =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(3, vec![(0, 1), (1, 2)]));
     assert_eq!(problem.graph().num_edges(), 2);
 }
 
@@ -30,8 +33,10 @@ fn test_edge_endpoints() {
 
 #[test]
 fn test_is_valid_matching() {
-    let problem =
-        MaximumMatching::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1, 1, 1]);
+    let problem = MaximumMatching::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1, 1, 1],
+    );
 
     // Valid: select edge 0 only
     assert!(problem.is_valid_matching(&[1, 0, 0]));
@@ -97,7 +102,8 @@ fn test_new() {
 
 #[test]
 fn test_unit_weights() {
-    let problem = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(3, vec![(0, 1), (1, 2)]));
+    let problem =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(3, vec![(0, 1), (1, 2)]));
     assert_eq!(problem.graph().num_vertices(), 3);
     assert_eq!(problem.graph().num_edges(), 2);
     assert_eq!(problem.weights(), vec![1, 1]);
@@ -105,7 +111,8 @@ fn test_unit_weights() {
 
 #[test]
 fn test_graph_accessor() {
-    let problem = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(3, vec![(0, 1), (1, 2)]));
+    let problem =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(3, vec![(0, 1), (1, 2)]));
     assert_eq!(problem.graph().num_vertices(), 3);
     assert_eq!(problem.graph().num_edges(), 2);
 }

--- a/src/unit_tests/models/graph/minimum_dominating_set.rs
+++ b/src/unit_tests/models/graph/minimum_dominating_set.rs
@@ -7,21 +7,26 @@ include!("../../jl_helpers.rs");
 
 #[test]
 fn test_dominating_set_creation() {
-    let problem = MinimumDominatingSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+    let problem = MinimumDominatingSet::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1i32; 4],
+    );
     assert_eq!(problem.graph().num_vertices(), 4);
     assert_eq!(problem.graph().num_edges(), 3);
 }
 
 #[test]
 fn test_dominating_set_with_weights() {
-    let problem =
-        MinimumDominatingSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![1, 2, 3]);
+    let problem = MinimumDominatingSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![1, 2, 3]);
     assert_eq!(problem.weights(), &[1, 2, 3]);
 }
 
 #[test]
 fn test_neighbors() {
-    let problem = MinimumDominatingSet::new(SimpleGraph::new(4, vec![(0, 1), (0, 2), (1, 2)]), vec![1i32; 4]);
+    let problem = MinimumDominatingSet::new(
+        SimpleGraph::new(4, vec![(0, 1), (0, 2), (1, 2)]),
+        vec![1i32; 4],
+    );
     let nbrs = problem.neighbors(0);
     assert!(nbrs.contains(&1));
     assert!(nbrs.contains(&2));
@@ -30,7 +35,8 @@ fn test_neighbors() {
 
 #[test]
 fn test_closed_neighborhood() {
-    let problem = MinimumDominatingSet::new(SimpleGraph::new(4, vec![(0, 1), (0, 2)]), vec![1i32; 4]);
+    let problem =
+        MinimumDominatingSet::new(SimpleGraph::new(4, vec![(0, 1), (0, 2)]), vec![1i32; 4]);
     let cn = problem.closed_neighborhood(0);
     assert!(cn.contains(&0));
     assert!(cn.contains(&1));
@@ -96,21 +102,22 @@ fn test_graph_accessor() {
 
 #[test]
 fn test_weights() {
-    let problem =
-        MinimumDominatingSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![5, 10, 15]);
+    let problem = MinimumDominatingSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![5, 10, 15]);
     assert_eq!(problem.weights(), &[5, 10, 15]);
 }
 
 #[test]
 fn test_edges() {
-    let problem = MinimumDominatingSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+    let problem =
+        MinimumDominatingSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
     let edges = problem.graph().edges();
     assert_eq!(edges.len(), 2);
 }
 
 #[test]
 fn test_has_edge() {
-    let problem = MinimumDominatingSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+    let problem =
+        MinimumDominatingSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
     assert!(problem.graph().has_edge(0, 1));
     assert!(problem.graph().has_edge(1, 0)); // Undirected
     assert!(problem.graph().has_edge(1, 2));

--- a/src/unit_tests/models/graph/minimum_vertex_cover.rs
+++ b/src/unit_tests/models/graph/minimum_vertex_cover.rs
@@ -7,7 +7,10 @@ include!("../../jl_helpers.rs");
 
 #[test]
 fn test_vertex_cover_creation() {
-    let problem = MinimumVertexCover::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+    let problem = MinimumVertexCover::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1i32; 4],
+    );
     assert_eq!(problem.graph().num_vertices(), 4);
     assert_eq!(problem.graph().num_edges(), 3);
     assert_eq!(problem.num_variables(), 4);
@@ -15,8 +18,7 @@ fn test_vertex_cover_creation() {
 
 #[test]
 fn test_vertex_cover_with_weights() {
-    let problem =
-        MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1)]), vec![1, 2, 3]);
+    let problem = MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1)]), vec![1, 2, 3]);
     assert_eq!(problem.weights().to_vec(), vec![1, 2, 3]);
 }
 

--- a/src/unit_tests/models/graph/traveling_salesman.rs
+++ b/src/unit_tests/models/graph/traveling_salesman.rs
@@ -23,9 +23,10 @@ fn test_traveling_salesman_creation() {
 #[test]
 fn test_traveling_salesman_unit_weights() {
     // i32 type is always considered weighted, even with uniform values
-    let problem = TravelingSalesman::<_, i32>::unit_weights(
-        SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)]),
-    );
+    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        5,
+        vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)],
+    ));
     assert!(problem.is_weighted());
     assert_eq!(problem.graph().num_vertices(), 5);
     assert_eq!(problem.graph().num_edges(), 5);
@@ -40,9 +41,10 @@ fn test_traveling_salesman_weighted() {
 #[test]
 fn test_evaluate_valid_cycle() {
     // C5 cycle graph with unit weights: all 5 edges form the only Hamiltonian cycle
-    let problem = TravelingSalesman::<_, i32>::unit_weights(
-        SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)]),
-    );
+    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        5,
+        vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)],
+    ));
     // Select all edges -> valid Hamiltonian cycle, cost = 5
     assert_eq!(problem.evaluate(&[1, 1, 1, 1, 1]), SolutionSize::Valid(5));
 }
@@ -59,9 +61,10 @@ fn test_evaluate_invalid_degree() {
 #[test]
 fn test_evaluate_invalid_not_connected() {
     // 6 vertices, two disjoint triangles: 0-1-2-0 and 3-4-5-3
-    let problem = TravelingSalesman::<_, i32>::unit_weights(
-        SimpleGraph::new(6, vec![(0, 1), (1, 2), (0, 2), (3, 4), (4, 5), (3, 5)]),
-    );
+    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        6,
+        vec![(0, 1), (1, 2), (0, 2), (3, 4), (4, 5), (3, 5)],
+    ));
     // Select all 6 edges: two disjoint cycles, not a single Hamiltonian cycle
     assert_eq!(problem.evaluate(&[1, 1, 1, 1, 1, 1]), SolutionSize::Invalid);
 }
@@ -69,17 +72,19 @@ fn test_evaluate_invalid_not_connected() {
 #[test]
 fn test_evaluate_invalid_wrong_edge_count() {
     // C5 with only 4 edges selected -> not enough edges
-    let problem = TravelingSalesman::<_, i32>::unit_weights(
-        SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)]),
-    );
+    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        5,
+        vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)],
+    ));
     assert_eq!(problem.evaluate(&[1, 1, 1, 1, 0]), SolutionSize::Invalid);
 }
 
 #[test]
 fn test_evaluate_no_edges_selected() {
-    let problem = TravelingSalesman::<_, i32>::unit_weights(
-        SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)]),
-    );
+    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        5,
+        vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)],
+    ));
     assert_eq!(problem.evaluate(&[0, 0, 0, 0, 0]), SolutionSize::Invalid);
 }
 
@@ -99,8 +104,10 @@ fn test_brute_force_k4() {
 #[test]
 fn test_brute_force_path_graph_no_solution() {
     // Instance 2 from issue: path graph, no Hamiltonian cycle exists
-    let problem =
-        TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]));
+    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        4,
+        vec![(0, 1), (1, 2), (2, 3)],
+    ));
     let solver = BruteForce::new();
     let solutions = solver.find_all_best(&problem);
     assert!(solutions.is_empty());
@@ -109,9 +116,10 @@ fn test_brute_force_path_graph_no_solution() {
 #[test]
 fn test_brute_force_c5_unique_solution() {
     // Instance 3 from issue: C5 cycle graph, unique Hamiltonian cycle
-    let problem = TravelingSalesman::<_, i32>::unit_weights(
-        SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)]),
-    );
+    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        5,
+        vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)],
+    ));
     let solver = BruteForce::new();
     let solutions = solver.find_all_best(&problem);
     assert_eq!(solutions.len(), 1);
@@ -122,9 +130,10 @@ fn test_brute_force_c5_unique_solution() {
 #[test]
 fn test_brute_force_bipartite_no_solution() {
     // Instance 4 from issue: K_{2,3} bipartite, no Hamiltonian cycle
-    let problem = TravelingSalesman::<_, i32>::unit_weights(
-        SimpleGraph::new(5, vec![(0, 2), (0, 3), (0, 4), (1, 2), (1, 3), (1, 4)]),
-    );
+    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        5,
+        vec![(0, 2), (0, 3), (0, 4), (1, 2), (1, 3), (1, 4)],
+    ));
     let solver = BruteForce::new();
     let solutions = solver.find_all_best(&problem);
     assert!(solutions.is_empty());
@@ -132,8 +141,10 @@ fn test_brute_force_bipartite_no_solution() {
 
 #[test]
 fn test_direction() {
-    let problem =
-        TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]));
+    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        3,
+        vec![(0, 1), (1, 2), (0, 2)],
+    ));
     assert_eq!(problem.direction(), Direction::Minimize);
 }
 
@@ -161,38 +172,50 @@ fn test_is_hamiltonian_cycle_function() {
 
 #[test]
 fn test_set_weights() {
-    let mut problem =
-        TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]));
+    let mut problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        3,
+        vec![(0, 1), (1, 2), (0, 2)],
+    ));
     problem.set_weights(vec![5, 10, 15]);
     assert_eq!(problem.weights(), vec![5, 10, 15]);
 }
 
 #[test]
 fn test_edges() {
-    let problem =
-        TravelingSalesman::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![10, 20, 30]);
+    let problem = TravelingSalesman::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![10, 20, 30],
+    );
     let edges = problem.edges();
     assert_eq!(edges.len(), 3);
 }
 
 #[test]
 fn test_new() {
-    let problem = TravelingSalesman::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![10, 20, 30]);
+    let problem = TravelingSalesman::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![10, 20, 30],
+    );
     assert_eq!(problem.graph().num_vertices(), 3);
     assert_eq!(problem.weights(), vec![10, 20, 30]);
 }
 
 #[test]
 fn test_unit_weights() {
-    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]));
+    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        3,
+        vec![(0, 1), (1, 2), (0, 2)],
+    ));
     assert_eq!(problem.weights(), vec![1, 1, 1]);
 }
 
 #[test]
 fn test_brute_force_triangle_weighted() {
     // Triangle with weights: unique Hamiltonian cycle using all edges
-    let problem =
-        TravelingSalesman::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![5, 10, 15]);
+    let problem = TravelingSalesman::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![5, 10, 15],
+    );
     let solver = BruteForce::new();
     let solutions = solver.find_all_best(&problem);
     assert_eq!(solutions.len(), 1);

--- a/src/unit_tests/models/specialized/biclique_cover.rs
+++ b/src/unit_tests/models/specialized/biclique_cover.rs
@@ -176,9 +176,10 @@ fn test_biclique_problem() {
 
 #[test]
 fn test_jl_parity_evaluation() {
-    let data: serde_json::Value =
-        serde_json::from_str(include_str!("../../../../tests/data/jl/biclique_cover.json"))
-            .unwrap();
+    let data: serde_json::Value = serde_json::from_str(include_str!(
+        "../../../../tests/data/jl/biclique_cover.json"
+    ))
+    .unwrap();
     for instance in data["instances"].as_array().unwrap() {
         let left_size = instance["instance"]["left_size"].as_u64().unwrap() as usize;
         let right_size = instance["instance"]["right_size"].as_u64().unwrap() as usize;
@@ -207,9 +208,6 @@ fn test_jl_parity_evaluation() {
         let best = BruteForce::new().find_all_best(&problem);
         let jl_best = jl_parse_configs_set(&instance["best_solutions"]);
         let rust_best: HashSet<Vec<usize>> = best.into_iter().collect();
-        assert_eq!(
-            rust_best, jl_best,
-            "BicliqueCover best solutions mismatch"
-        );
+        assert_eq!(rust_best, jl_best, "BicliqueCover best solutions mismatch");
     }
 }

--- a/src/unit_tests/models/specialized/biclique_cover.rs
+++ b/src/unit_tests/models/specialized/biclique_cover.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::solvers::BruteForce;
+use crate::topology::BipartiteGraph;
 use crate::traits::{OptimizationProblem, Problem};
 use crate::types::{Direction, SolutionSize};
 
@@ -7,7 +8,8 @@ include!("../../jl_helpers.rs");
 
 #[test]
 fn test_biclique_cover_creation() {
-    let problem = BicliqueCover::new(2, 2, vec![(0, 2), (0, 3), (1, 2)], 2);
+    let graph = BipartiteGraph::new(2, 2, vec![(0, 0), (0, 1), (1, 0)]);
+    let problem = BicliqueCover::new(graph, 2);
     assert_eq!(problem.num_vertices(), 4);
     assert_eq!(problem.num_edges(), 3);
     assert_eq!(problem.k(), 2);
@@ -19,7 +21,7 @@ fn test_from_matrix() {
     // Matrix:
     // [[1, 1],
     //  [1, 0]]
-    // Edges: (0,2), (0,3), (1,2)
+    // Edges: (0,0), (0,1), (1,0) in local coords
     let matrix = vec![vec![1, 1], vec![1, 0]];
     let problem = BicliqueCover::from_matrix(&matrix, 2);
     assert_eq!(problem.num_vertices(), 4);
@@ -28,7 +30,8 @@ fn test_from_matrix() {
 
 #[test]
 fn test_get_biclique_memberships() {
-    let problem = BicliqueCover::new(2, 2, vec![(0, 2)], 1);
+    let graph = BipartiteGraph::new(2, 2, vec![(0, 0)]);
+    let problem = BicliqueCover::new(graph, 1);
     // Config: vertex 0 in biclique 0, vertex 2 in biclique 0
     // Variables: [v0_b0, v1_b0, v2_b0, v3_b0]
     let config = vec![1, 0, 1, 0];
@@ -41,7 +44,8 @@ fn test_get_biclique_memberships() {
 
 #[test]
 fn test_is_edge_covered() {
-    let problem = BicliqueCover::new(2, 2, vec![(0, 2)], 1);
+    let graph = BipartiteGraph::new(2, 2, vec![(0, 0)]);
+    let problem = BicliqueCover::new(graph, 1);
     // Put vertex 0 and 2 in biclique 0
     let config = vec![1, 0, 1, 0];
     assert!(problem.is_edge_covered(0, 2, &config));
@@ -53,7 +57,8 @@ fn test_is_edge_covered() {
 
 #[test]
 fn test_is_valid_cover() {
-    let problem = BicliqueCover::new(2, 2, vec![(0, 2), (0, 3)], 1);
+    let graph = BipartiteGraph::new(2, 2, vec![(0, 0), (0, 1)]);
+    let problem = BicliqueCover::new(graph, 1);
     // Put 0, 2, 3 in biclique 0 -> covers both edges
     let config = vec![1, 0, 1, 1];
     assert!(problem.is_valid_cover(&config));
@@ -65,7 +70,8 @@ fn test_is_valid_cover() {
 
 #[test]
 fn test_evaluate() {
-    let problem = BicliqueCover::new(2, 2, vec![(0, 2)], 1);
+    let graph = BipartiteGraph::new(2, 2, vec![(0, 0)]);
+    let problem = BicliqueCover::new(graph, 1);
 
     // Valid cover with size 2
     assert_eq!(problem.evaluate(&[1, 0, 1, 0]), SolutionSize::Valid(2));
@@ -76,8 +82,9 @@ fn test_evaluate() {
 
 #[test]
 fn test_brute_force_simple() {
-    // Single edge (0, 2) with k=1
-    let problem = BicliqueCover::new(2, 2, vec![(0, 2)], 1);
+    // Single edge (0, 0) in local coords with k=1
+    let graph = BipartiteGraph::new(2, 2, vec![(0, 0)]);
+    let problem = BicliqueCover::new(graph, 1);
     let solver = BruteForce::new();
 
     let solutions = solver.find_all_best(&problem);
@@ -91,8 +98,9 @@ fn test_brute_force_simple() {
 #[test]
 fn test_brute_force_two_bicliques() {
     // Edges that need 2 bicliques to cover efficiently
-    // (0,2), (1,3) - these don't share vertices
-    let problem = BicliqueCover::new(2, 2, vec![(0, 2), (1, 3)], 2);
+    // (0,0), (1,1) in local coords - these don't share vertices
+    let graph = BipartiteGraph::new(2, 2, vec![(0, 0), (1, 1)]);
+    let problem = BicliqueCover::new(graph, 2);
     let solver = BruteForce::new();
 
     let solutions = solver.find_all_best(&problem);
@@ -103,7 +111,8 @@ fn test_brute_force_two_bicliques() {
 
 #[test]
 fn test_count_covered_edges() {
-    let problem = BicliqueCover::new(2, 2, vec![(0, 2), (0, 3), (1, 2)], 1);
+    let graph = BipartiteGraph::new(2, 2, vec![(0, 0), (0, 1), (1, 0)]);
+    let problem = BicliqueCover::new(graph, 1);
     // Cover only (0,2): put 0 and 2 in biclique
     let config = vec![1, 0, 1, 0];
     assert_eq!(problem.count_covered_edges(&config), 1);
@@ -128,13 +137,15 @@ fn test_is_biclique_cover_function() {
 
 #[test]
 fn test_direction() {
-    let problem = BicliqueCover::new(1, 1, vec![(0, 1)], 1);
+    let graph = BipartiteGraph::new(1, 1, vec![(0, 0)]);
+    let problem = BicliqueCover::new(graph, 1);
     assert_eq!(problem.direction(), Direction::Minimize);
 }
 
 #[test]
 fn test_empty_edges() {
-    let problem = BicliqueCover::new(2, 2, vec![], 1);
+    let graph = BipartiteGraph::new(2, 2, vec![]);
+    let problem = BicliqueCover::new(graph, 1);
     // No edges to cover -> valid with size 0
     assert_eq!(problem.evaluate(&[0, 0, 0, 0]), SolutionSize::Valid(0));
 }
@@ -144,8 +155,9 @@ fn test_biclique_problem() {
     use crate::traits::{OptimizationProblem, Problem};
     use crate::types::Direction;
 
-    // Single edge (0, 2) with k=1, 2 left + 2 right vertices
-    let problem = BicliqueCover::new(2, 2, vec![(0, 2)], 1);
+    // Single edge (0,0) in local coords with k=1, 2 left + 2 right vertices
+    let graph = BipartiteGraph::new(2, 2, vec![(0, 0)]);
+    let problem = BicliqueCover::new(graph, 1);
 
     // dims: 4 vertices * 1 biclique = 4 binary variables
     assert_eq!(problem.dims(), vec![2, 2, 2, 2]);
@@ -167,7 +179,8 @@ fn test_biclique_problem() {
     assert_eq!(problem.direction(), Direction::Minimize);
 
     // Test with no edges: any config is valid
-    let empty_problem = BicliqueCover::new(2, 2, vec![], 1);
+    let empty_graph = BipartiteGraph::new(2, 2, vec![]);
+    let empty_problem = BicliqueCover::new(empty_graph, 1);
     assert_eq!(
         empty_problem.evaluate(&[0, 0, 0, 0]),
         SolutionSize::Valid(0)
@@ -183,9 +196,15 @@ fn test_jl_parity_evaluation() {
     for instance in data["instances"].as_array().unwrap() {
         let left_size = instance["instance"]["left_size"].as_u64().unwrap() as usize;
         let right_size = instance["instance"]["right_size"].as_u64().unwrap() as usize;
-        let edges = jl_parse_edges(&instance["instance"]);
+        let unified_edges = jl_parse_edges(&instance["instance"]);
+        // Convert from unified coords to bipartite-local coords
+        let local_edges: Vec<(usize, usize)> = unified_edges
+            .iter()
+            .map(|&(l, r)| (l, r - left_size))
+            .collect();
         let k = instance["instance"]["k"].as_u64().unwrap() as usize;
-        let problem = BicliqueCover::new(left_size, right_size, edges, k);
+        let graph = BipartiteGraph::new(left_size, right_size, local_edges);
+        let problem = BicliqueCover::new(graph, k);
         for eval in instance["evaluations"].as_array().unwrap() {
             let config = jl_parse_config(&eval["config"]);
             let result = problem.evaluate(&config);

--- a/src/unit_tests/problem_size.rs
+++ b/src/unit_tests/problem_size.rs
@@ -1,18 +1,18 @@
-//! Tests for Problem::problem_size() implementations.
+//! Tests for problem_size() free function and Problem size implementations.
 
 use crate::models::graph::*;
 use crate::models::optimization::*;
 use crate::models::satisfiability::*;
 use crate::models::set::*;
 use crate::models::specialized::*;
-use crate::topology::SimpleGraph;
-use crate::traits::Problem;
+use crate::topology::{BipartiteGraph, SimpleGraph};
+use crate::traits::{problem_size, Problem};
 
 #[test]
 fn test_problem_size_mis() {
     let g = SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]);
     let mis = MaximumIndependentSet::new(g, vec![1i32; 4]);
-    let size = mis.problem_size();
+    let size = problem_size(&mis);
     assert_eq!(size.get("num_vertices"), Some(4));
     assert_eq!(size.get("num_edges"), Some(3));
 }
@@ -21,7 +21,7 @@ fn test_problem_size_mis() {
 fn test_problem_size_max_clique() {
     let g = SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]);
     let mc = MaximumClique::new(g, vec![1i32; 3]);
-    let size = mc.problem_size();
+    let size = problem_size(&mc);
     assert_eq!(size.get("num_vertices"), Some(3));
     assert_eq!(size.get("num_edges"), Some(3));
 }
@@ -30,7 +30,7 @@ fn test_problem_size_max_clique() {
 fn test_problem_size_min_vc() {
     let g = SimpleGraph::new(3, vec![(0, 1), (1, 2)]);
     let mvc = MinimumVertexCover::new(g, vec![1i32; 3]);
-    let size = mvc.problem_size();
+    let size = problem_size(&mvc);
     assert_eq!(size.get("num_vertices"), Some(3));
     assert_eq!(size.get("num_edges"), Some(2));
 }
@@ -39,7 +39,7 @@ fn test_problem_size_min_vc() {
 fn test_problem_size_min_ds() {
     let g = SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]);
     let mds = MinimumDominatingSet::new(g, vec![1i32; 4]);
-    let size = mds.problem_size();
+    let size = problem_size(&mds);
     assert_eq!(size.get("num_vertices"), Some(4));
     assert_eq!(size.get("num_edges"), Some(3));
 }
@@ -48,7 +48,7 @@ fn test_problem_size_min_ds() {
 fn test_problem_size_max_cut() {
     let g = SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]);
     let mc = MaxCut::new(g, vec![1i32; 3]);
-    let size = mc.problem_size();
+    let size = problem_size(&mc);
     assert_eq!(size.get("num_vertices"), Some(3));
     assert_eq!(size.get("num_edges"), Some(3));
 }
@@ -57,7 +57,7 @@ fn test_problem_size_max_cut() {
 fn test_problem_size_maximum_matching() {
     let g = SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]);
     let mm = MaximumMatching::new(g, vec![1i32; 3]);
-    let size = mm.problem_size();
+    let size = problem_size(&mm);
     assert_eq!(size.get("num_vertices"), Some(4));
     assert_eq!(size.get("num_edges"), Some(3));
 }
@@ -66,7 +66,7 @@ fn test_problem_size_maximum_matching() {
 fn test_problem_size_maximal_is() {
     let g = SimpleGraph::new(3, vec![(0, 1), (1, 2)]);
     let mis = MaximalIS::new(g, vec![1i32; 3]);
-    let size = mis.problem_size();
+    let size = problem_size(&mis);
     assert_eq!(size.get("num_vertices"), Some(3));
     assert_eq!(size.get("num_edges"), Some(2));
 }
@@ -76,17 +76,18 @@ fn test_problem_size_kcoloring() {
     use crate::variant::KN;
     let g = SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]);
     let kc = KColoring::<KN, _>::with_k(g, 3);
-    let size = kc.problem_size();
+    let size = problem_size(&kc);
     assert_eq!(size.get("num_vertices"), Some(3));
     assert_eq!(size.get("num_edges"), Some(3));
-    assert_eq!(size.get("num_colors"), Some(3));
+    // k is a problem parameter, not a size metric
+    assert_eq!(size.get("num_colors"), None);
 }
 
 #[test]
 fn test_problem_size_tsp() {
     let g = SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]);
     let tsp = TravelingSalesman::new(g, vec![1i32; 3]);
-    let size = tsp.problem_size();
+    let size = problem_size(&tsp);
     assert_eq!(size.get("num_vertices"), Some(3));
     assert_eq!(size.get("num_edges"), Some(3));
 }
@@ -98,7 +99,7 @@ fn test_problem_size_sat() {
         3,
         vec![CNFClause::new(vec![1, -2]), CNFClause::new(vec![2, 3])],
     );
-    let size = sat.problem_size();
+    let size = problem_size(&sat);
     assert_eq!(size.get("num_vars"), Some(3));
     assert_eq!(size.get("num_clauses"), Some(2));
     assert_eq!(size.get("num_literals"), Some(4));
@@ -115,7 +116,7 @@ fn test_problem_size_ksat() {
             CNFClause::new(vec![-1, 2, -3]),
         ],
     );
-    let size = ksat.problem_size();
+    let size = problem_size(&ksat);
     assert_eq!(size.get("num_vars"), Some(3));
     assert_eq!(size.get("num_clauses"), Some(2));
     assert_eq!(size.get("num_literals"), Some(6));
@@ -124,7 +125,7 @@ fn test_problem_size_ksat() {
 #[test]
 fn test_problem_size_qubo() {
     let qubo = QUBO::<f64>::new(vec![1.0, 2.0, 3.0], vec![]);
-    let size = qubo.problem_size();
+    let size = problem_size(&qubo);
     assert_eq!(size.get("num_vars"), Some(3));
 }
 
@@ -135,7 +136,7 @@ fn test_problem_size_spinglass() {
         vec![((0, 1), 1.0), ((1, 2), -1.0)],
         vec![0.0, 0.5, -0.5],
     );
-    let size = sg.problem_size();
+    let size = problem_size(&sg);
     assert_eq!(size.get("num_spins"), Some(3));
     assert_eq!(size.get("num_interactions"), Some(2));
 }
@@ -149,7 +150,7 @@ fn test_problem_size_ilp() {
         vec![(0, 1.0), (1, 2.0)],
         ObjectiveSense::Maximize,
     );
-    let size = ilp.problem_size();
+    let size = problem_size(&ilp);
     assert_eq!(size.get("num_vars"), Some(2));
     assert_eq!(size.get("num_constraints"), Some(1));
 }
@@ -157,7 +158,7 @@ fn test_problem_size_ilp() {
 #[test]
 fn test_problem_size_factoring() {
     let f = Factoring::new(2, 3, 6);
-    let size = f.problem_size();
+    let size = problem_size(&f);
     assert_eq!(size.get("num_bits_first"), Some(2));
     assert_eq!(size.get("num_bits_second"), Some(3));
 }
@@ -170,7 +171,7 @@ fn test_problem_size_circuitsat() {
         BooleanExpr::and(vec![BooleanExpr::var("x"), BooleanExpr::var("y")]),
     )]);
     let problem = CircuitSAT::new(circuit);
-    let size = problem.problem_size();
+    let size = problem_size(&problem);
     assert_eq!(size.get("num_variables"), Some(problem.num_variables()));
     assert_eq!(size.get("num_assignments"), Some(1));
 }
@@ -178,15 +179,15 @@ fn test_problem_size_circuitsat() {
 #[test]
 fn test_problem_size_paintshop() {
     let ps = PaintShop::new(vec!["a", "b", "a", "c", "c", "b"]);
-    let size = ps.problem_size();
+    let size = problem_size(&ps);
     assert_eq!(size.get("num_cars"), Some(3));
     assert_eq!(size.get("num_sequence"), Some(6));
 }
 
 #[test]
 fn test_problem_size_biclique_cover() {
-    let bc = BicliqueCover::new(2, 3, vec![(0, 2), (0, 3), (1, 4)], 2);
-    let size = bc.problem_size();
+    let bc = BicliqueCover::new(BipartiteGraph::new(2, 3, vec![(0, 0), (0, 1), (1, 2)]), 2);
+    let size = problem_size(&bc);
     assert_eq!(size.get("left_size"), Some(2));
     assert_eq!(size.get("right_size"), Some(3));
     assert_eq!(size.get("num_edges"), Some(3));
@@ -196,7 +197,7 @@ fn test_problem_size_biclique_cover() {
 #[test]
 fn test_problem_size_bmf() {
     let bmf = BMF::new(vec![vec![true, false], vec![false, true]], 2);
-    let size = bmf.problem_size();
+    let size = problem_size(&bmf);
     assert_eq!(size.get("m"), Some(2));
     assert_eq!(size.get("n"), Some(2));
     assert_eq!(size.get("rank"), Some(2));
@@ -205,7 +206,7 @@ fn test_problem_size_bmf() {
 #[test]
 fn test_problem_size_set_packing() {
     let sp = MaximumSetPacking::<i32>::new(vec![vec![0, 1], vec![1, 2], vec![2, 3]]);
-    let size = sp.problem_size();
+    let size = problem_size(&sp);
     assert_eq!(size.get("num_sets"), Some(3));
     assert_eq!(size.get("universe_size"), Some(4));
 }
@@ -213,7 +214,7 @@ fn test_problem_size_set_packing() {
 #[test]
 fn test_problem_size_set_covering() {
     let sc = MinimumSetCovering::<i32>::new(4, vec![vec![0, 1], vec![1, 2], vec![2, 3]]);
-    let size = sc.problem_size();
+    let size = problem_size(&sc);
     assert_eq!(size.get("num_sets"), Some(3));
     assert_eq!(size.get("universe_size"), Some(4));
 }

--- a/src/unit_tests/problem_size.rs
+++ b/src/unit_tests/problem_size.rs
@@ -1,0 +1,229 @@
+//! Tests for Problem::problem_size() implementations.
+
+use crate::models::graph::*;
+use crate::models::optimization::*;
+use crate::models::satisfiability::*;
+use crate::models::set::*;
+use crate::models::specialized::*;
+use crate::topology::SimpleGraph;
+use crate::traits::Problem;
+
+#[test]
+fn test_problem_size_mis() {
+    let g = SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]);
+    let mis = MaximumIndependentSet::new(g, vec![1i32; 4]);
+    let size = mis.problem_size();
+    assert_eq!(size.get("num_vertices"), Some(4));
+    assert_eq!(size.get("num_edges"), Some(3));
+}
+
+#[test]
+fn test_problem_size_max_clique() {
+    let g = SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]);
+    let mc = MaximumClique::new(g, vec![1i32; 3]);
+    let size = mc.problem_size();
+    assert_eq!(size.get("num_vertices"), Some(3));
+    assert_eq!(size.get("num_edges"), Some(3));
+}
+
+#[test]
+fn test_problem_size_min_vc() {
+    let g = SimpleGraph::new(3, vec![(0, 1), (1, 2)]);
+    let mvc = MinimumVertexCover::new(g, vec![1i32; 3]);
+    let size = mvc.problem_size();
+    assert_eq!(size.get("num_vertices"), Some(3));
+    assert_eq!(size.get("num_edges"), Some(2));
+}
+
+#[test]
+fn test_problem_size_min_ds() {
+    let g = SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]);
+    let mds = MinimumDominatingSet::new(g, vec![1i32; 4]);
+    let size = mds.problem_size();
+    assert_eq!(size.get("num_vertices"), Some(4));
+    assert_eq!(size.get("num_edges"), Some(3));
+}
+
+#[test]
+fn test_problem_size_max_cut() {
+    let g = SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]);
+    let mc = MaxCut::new(g, vec![1i32; 3]);
+    let size = mc.problem_size();
+    assert_eq!(size.get("num_vertices"), Some(3));
+    assert_eq!(size.get("num_edges"), Some(3));
+}
+
+#[test]
+fn test_problem_size_maximum_matching() {
+    let g = SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]);
+    let mm = MaximumMatching::new(g, vec![1i32; 3]);
+    let size = mm.problem_size();
+    assert_eq!(size.get("num_vertices"), Some(4));
+    assert_eq!(size.get("num_edges"), Some(3));
+}
+
+#[test]
+fn test_problem_size_maximal_is() {
+    let g = SimpleGraph::new(3, vec![(0, 1), (1, 2)]);
+    let mis = MaximalIS::new(g, vec![1i32; 3]);
+    let size = mis.problem_size();
+    assert_eq!(size.get("num_vertices"), Some(3));
+    assert_eq!(size.get("num_edges"), Some(2));
+}
+
+#[test]
+fn test_problem_size_kcoloring() {
+    use crate::variant::KN;
+    let g = SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]);
+    let kc = KColoring::<KN, _>::with_k(g, 3);
+    let size = kc.problem_size();
+    assert_eq!(size.get("num_vertices"), Some(3));
+    assert_eq!(size.get("num_edges"), Some(3));
+    assert_eq!(size.get("num_colors"), Some(3));
+}
+
+#[test]
+fn test_problem_size_tsp() {
+    let g = SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]);
+    let tsp = TravelingSalesman::new(g, vec![1i32; 3]);
+    let size = tsp.problem_size();
+    assert_eq!(size.get("num_vertices"), Some(3));
+    assert_eq!(size.get("num_edges"), Some(3));
+}
+
+#[test]
+fn test_problem_size_sat() {
+    use crate::models::satisfiability::CNFClause;
+    let sat = Satisfiability::new(3, vec![
+        CNFClause::new(vec![1, -2]),
+        CNFClause::new(vec![2, 3]),
+    ]);
+    let size = sat.problem_size();
+    assert_eq!(size.get("num_vars"), Some(3));
+    assert_eq!(size.get("num_clauses"), Some(2));
+    assert_eq!(size.get("num_literals"), Some(4));
+}
+
+#[test]
+fn test_problem_size_ksat() {
+    use crate::models::satisfiability::CNFClause;
+    use crate::variant::K3;
+    let ksat = KSatisfiability::<K3>::new(3, vec![
+        CNFClause::new(vec![1, -2, 3]),
+        CNFClause::new(vec![-1, 2, -3]),
+    ]);
+    let size = ksat.problem_size();
+    assert_eq!(size.get("num_vars"), Some(3));
+    assert_eq!(size.get("num_clauses"), Some(2));
+    assert_eq!(size.get("num_literals"), Some(6));
+}
+
+#[test]
+fn test_problem_size_qubo() {
+    let qubo = QUBO::<f64>::new(vec![1.0, 2.0, 3.0], vec![]);
+    let size = qubo.problem_size();
+    assert_eq!(size.get("num_vars"), Some(3));
+}
+
+#[test]
+fn test_problem_size_spinglass() {
+    let sg = SpinGlass::<SimpleGraph, f64>::new(
+        3,
+        vec![((0, 1), 1.0), ((1, 2), -1.0)],
+        vec![0.0, 0.5, -0.5],
+    );
+    let size = sg.problem_size();
+    assert_eq!(size.get("num_spins"), Some(3));
+    assert_eq!(size.get("num_interactions"), Some(2));
+}
+
+#[test]
+fn test_problem_size_ilp() {
+    use crate::models::optimization::{LinearConstraint, ObjectiveSense};
+    let ilp = ILP::binary(
+        2,
+        vec![LinearConstraint::le(vec![(0, 1.0), (1, 1.0)], 3.0)],
+        vec![(0, 1.0), (1, 2.0)],
+        ObjectiveSense::Maximize,
+    );
+    let size = ilp.problem_size();
+    assert_eq!(size.get("num_vars"), Some(2));
+    assert_eq!(size.get("num_constraints"), Some(1));
+}
+
+#[test]
+fn test_problem_size_factoring() {
+    let f = Factoring::new(2, 3, 6);
+    let size = f.problem_size();
+    assert_eq!(size.get("num_bits_first"), Some(2));
+    assert_eq!(size.get("num_bits_second"), Some(3));
+}
+
+#[test]
+fn test_problem_size_circuitsat() {
+    use crate::models::specialized::{BooleanExpr, Assignment, Circuit};
+    let circuit = Circuit::new(vec![
+        Assignment::new(
+            vec!["c".to_string()],
+            BooleanExpr::and(vec![BooleanExpr::var("x"), BooleanExpr::var("y")]),
+        ),
+    ]);
+    let problem = CircuitSAT::new(circuit);
+    let size = problem.problem_size();
+    assert_eq!(size.get("num_variables"), Some(problem.num_variables()));
+    assert_eq!(size.get("num_assignments"), Some(1));
+}
+
+#[test]
+fn test_problem_size_paintshop() {
+    let ps = PaintShop::new(vec!["a", "b", "a", "c", "c", "b"]);
+    let size = ps.problem_size();
+    assert_eq!(size.get("num_cars"), Some(3));
+    assert_eq!(size.get("num_sequence"), Some(6));
+}
+
+#[test]
+fn test_problem_size_biclique_cover() {
+    let bc = BicliqueCover::new(2, 3, vec![(0, 2), (0, 3), (1, 4)], 2);
+    let size = bc.problem_size();
+    assert_eq!(size.get("left_size"), Some(2));
+    assert_eq!(size.get("right_size"), Some(3));
+    assert_eq!(size.get("num_edges"), Some(3));
+    assert_eq!(size.get("rank"), Some(2));
+}
+
+#[test]
+fn test_problem_size_bmf() {
+    let bmf = BMF::new(vec![vec![true, false], vec![false, true]], 2);
+    let size = bmf.problem_size();
+    assert_eq!(size.get("m"), Some(2));
+    assert_eq!(size.get("n"), Some(2));
+    assert_eq!(size.get("rank"), Some(2));
+}
+
+#[test]
+fn test_problem_size_set_packing() {
+    let sp = MaximumSetPacking::<i32>::new(vec![
+        vec![0, 1],
+        vec![1, 2],
+        vec![2, 3],
+    ]);
+    let size = sp.problem_size();
+    assert_eq!(size.get("num_sets"), Some(3));
+    assert_eq!(size.get("universe_size"), Some(4));
+}
+
+#[test]
+fn test_problem_size_set_covering() {
+    let sc = MinimumSetCovering::<i32>::new(
+        4,
+        vec![
+            vec![0, 1],
+            vec![1, 2],
+            vec![2, 3],
+        ],
+    );
+    let size = sc.problem_size();
+    assert_eq!(size.get("num_sets"), Some(3));
+    assert_eq!(size.get("universe_size"), Some(4));
+}

--- a/src/unit_tests/problem_size.rs
+++ b/src/unit_tests/problem_size.rs
@@ -94,10 +94,10 @@ fn test_problem_size_tsp() {
 #[test]
 fn test_problem_size_sat() {
     use crate::models::satisfiability::CNFClause;
-    let sat = Satisfiability::new(3, vec![
-        CNFClause::new(vec![1, -2]),
-        CNFClause::new(vec![2, 3]),
-    ]);
+    let sat = Satisfiability::new(
+        3,
+        vec![CNFClause::new(vec![1, -2]), CNFClause::new(vec![2, 3])],
+    );
     let size = sat.problem_size();
     assert_eq!(size.get("num_vars"), Some(3));
     assert_eq!(size.get("num_clauses"), Some(2));
@@ -108,10 +108,13 @@ fn test_problem_size_sat() {
 fn test_problem_size_ksat() {
     use crate::models::satisfiability::CNFClause;
     use crate::variant::K3;
-    let ksat = KSatisfiability::<K3>::new(3, vec![
-        CNFClause::new(vec![1, -2, 3]),
-        CNFClause::new(vec![-1, 2, -3]),
-    ]);
+    let ksat = KSatisfiability::<K3>::new(
+        3,
+        vec![
+            CNFClause::new(vec![1, -2, 3]),
+            CNFClause::new(vec![-1, 2, -3]),
+        ],
+    );
     let size = ksat.problem_size();
     assert_eq!(size.get("num_vars"), Some(3));
     assert_eq!(size.get("num_clauses"), Some(2));
@@ -161,13 +164,11 @@ fn test_problem_size_factoring() {
 
 #[test]
 fn test_problem_size_circuitsat() {
-    use crate::models::specialized::{BooleanExpr, Assignment, Circuit};
-    let circuit = Circuit::new(vec![
-        Assignment::new(
-            vec!["c".to_string()],
-            BooleanExpr::and(vec![BooleanExpr::var("x"), BooleanExpr::var("y")]),
-        ),
-    ]);
+    use crate::models::specialized::{Assignment, BooleanExpr, Circuit};
+    let circuit = Circuit::new(vec![Assignment::new(
+        vec!["c".to_string()],
+        BooleanExpr::and(vec![BooleanExpr::var("x"), BooleanExpr::var("y")]),
+    )]);
     let problem = CircuitSAT::new(circuit);
     let size = problem.problem_size();
     assert_eq!(size.get("num_variables"), Some(problem.num_variables()));
@@ -203,11 +204,7 @@ fn test_problem_size_bmf() {
 
 #[test]
 fn test_problem_size_set_packing() {
-    let sp = MaximumSetPacking::<i32>::new(vec![
-        vec![0, 1],
-        vec![1, 2],
-        vec![2, 3],
-    ]);
+    let sp = MaximumSetPacking::<i32>::new(vec![vec![0, 1], vec![1, 2], vec![2, 3]]);
     let size = sp.problem_size();
     assert_eq!(size.get("num_sets"), Some(3));
     assert_eq!(size.get("universe_size"), Some(4));
@@ -215,14 +212,7 @@ fn test_problem_size_set_packing() {
 
 #[test]
 fn test_problem_size_set_covering() {
-    let sc = MinimumSetCovering::<i32>::new(
-        4,
-        vec![
-            vec![0, 1],
-            vec![1, 2],
-            vec![2, 3],
-        ],
-    );
+    let sc = MinimumSetCovering::<i32>::new(4, vec![vec![0, 1], vec![1, 2], vec![2, 3]]);
     let size = sc.problem_size();
     assert_eq!(size.get("num_sets"), Some(3));
     assert_eq!(size.get("universe_size"), Some(4));

--- a/src/unit_tests/reduction_graph.rs
+++ b/src/unit_tests/reduction_graph.rs
@@ -46,7 +46,7 @@ fn test_bidirectional_reductions() {
 #[test]
 fn test_find_path_with_cost_function() {
     let graph = ReductionGraph::new();
-    let input_size = ProblemSize::new(vec![("n", 100), ("m", 200)]);
+    let input_size = ProblemSize::new(vec![("num_vertices", 100), ("num_edges", 200)]);
 
     let src = ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
     let dst = ReductionGraph::variant_to_map(&MinimumVertexCover::<SimpleGraph, i32>::variant());
@@ -74,7 +74,14 @@ fn test_multi_step_path() {
     // Factoring -> CircuitSAT -> SpinGlass<SimpleGraph, i32> is a 2-step path
     let src = ReductionGraph::variant_to_map(&crate::models::specialized::Factoring::variant());
     let dst = ReductionGraph::variant_to_map(&SpinGlass::<SimpleGraph, i32>::variant());
-    let path = graph.find_cheapest_path("Factoring", &src, "SpinGlass", &dst, &ProblemSize::new(vec![]), &MinimizeSteps);
+    let path = graph.find_cheapest_path(
+        "Factoring",
+        &src,
+        "SpinGlass",
+        &dst,
+        &ProblemSize::new(vec![]),
+        &MinimizeSteps,
+    );
 
     assert!(
         path.is_some(),
@@ -107,9 +114,17 @@ fn test_problem_size_propagation() {
 
     assert!(path.is_some());
 
-    let src2 = ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
+    let src2 =
+        ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
     let dst2 = ReductionGraph::variant_to_map(&MaximumSetPacking::<i32>::variant());
-    let path2 = graph.find_cheapest_path("MaximumIndependentSet", &src2, "MaximumSetPacking", &dst2, &ProblemSize::new(vec![]), &MinimizeSteps);
+    let path2 = graph.find_cheapest_path(
+        "MaximumIndependentSet",
+        &src2,
+        "MaximumSetPacking",
+        &dst2,
+        &ProblemSize::new(vec![]),
+        &MinimizeSteps,
+    );
     assert!(path2.is_some());
 }
 
@@ -167,7 +182,14 @@ fn test_find_indirect_path() {
     let paths = graph.find_all_paths("MaximumSetPacking", &src, "MinimumVertexCover", &dst);
     assert!(!paths.is_empty());
 
-    let shortest = graph.find_cheapest_path("MaximumSetPacking", &src, "MinimumVertexCover", &dst, &ProblemSize::new(vec![]), &MinimizeSteps);
+    let shortest = graph.find_cheapest_path(
+        "MaximumSetPacking",
+        &src,
+        "MinimumVertexCover",
+        &dst,
+        &ProblemSize::new(vec![]),
+        &MinimizeSteps,
+    );
     assert!(shortest.is_some());
     assert_eq!(shortest.unwrap().len(), 2);
 }
@@ -185,14 +207,33 @@ fn test_no_path_exists() {
 #[test]
 fn test_bidirectional_paths() {
     let graph = ReductionGraph::new();
-    let is_var = ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
+    let is_var =
+        ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
     let vc_var = ReductionGraph::variant_to_map(&MinimumVertexCover::<SimpleGraph, i32>::variant());
     let sg_var = ReductionGraph::variant_to_map(&SpinGlass::<SimpleGraph, f64>::variant());
     let qubo_var = ReductionGraph::variant_to_map(&QUBO::<f64>::variant());
 
-    assert!(!graph.find_all_paths("MaximumIndependentSet", &is_var, "MinimumVertexCover", &vc_var).is_empty());
-    assert!(!graph.find_all_paths("MinimumVertexCover", &vc_var, "MaximumIndependentSet", &is_var).is_empty());
+    assert!(!graph
+        .find_all_paths(
+            "MaximumIndependentSet",
+            &is_var,
+            "MinimumVertexCover",
+            &vc_var
+        )
+        .is_empty());
+    assert!(!graph
+        .find_all_paths(
+            "MinimumVertexCover",
+            &vc_var,
+            "MaximumIndependentSet",
+            &is_var
+        )
+        .is_empty());
 
-    assert!(!graph.find_all_paths("SpinGlass", &sg_var, "QUBO", &qubo_var).is_empty());
-    assert!(!graph.find_all_paths("QUBO", &qubo_var, "SpinGlass", &sg_var).is_empty());
+    assert!(!graph
+        .find_all_paths("SpinGlass", &sg_var, "QUBO", &qubo_var)
+        .is_empty());
+    assert!(!graph
+        .find_all_paths("QUBO", &qubo_var, "SpinGlass", &sg_var)
+        .is_empty());
 }

--- a/src/unit_tests/rules/coloring_ilp.rs
+++ b/src/unit_tests/rules/coloring_ilp.rs
@@ -144,7 +144,8 @@ fn test_solution_extraction() {
 
 #[test]
 fn test_ilp_structure() {
-    let problem = KColoring::<K3, _>::new(SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]));
+    let problem =
+        KColoring::<K3, _>::new(SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]));
     let reduction = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -174,8 +175,10 @@ fn test_empty_graph() {
 #[test]
 fn test_complete_graph_k4() {
     // K4 needs 4 colors
-    let problem =
-        KColoring::<K4, _>::new(SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]));
+    let problem = KColoring::<K4, _>::new(SimpleGraph::new(
+        4,
+        vec![(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)],
+    ));
     let reduction = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -195,8 +198,10 @@ fn test_complete_graph_k4() {
 #[test]
 fn test_complete_graph_k4_with_3_colors_infeasible() {
     // K4 cannot be 3-colored
-    let problem =
-        KColoring::<K3, _>::new(SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]));
+    let problem = KColoring::<K3, _>::new(SimpleGraph::new(
+        4,
+        vec![(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)],
+    ));
     let reduction = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -209,7 +214,8 @@ fn test_complete_graph_k4_with_3_colors_infeasible() {
 fn test_bipartite_graph() {
     // Complete bipartite K_{2,2}: 0-2, 0-3, 1-2, 1-3
     // This is 2-colorable
-    let problem = KColoring::<K2, _>::new(SimpleGraph::new(4, vec![(0, 2), (0, 3), (1, 2), (1, 3)]));
+    let problem =
+        KColoring::<K2, _>::new(SimpleGraph::new(4, vec![(0, 2), (0, 3), (1, 2), (1, 3)]));
     let reduction = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 

--- a/src/unit_tests/rules/cost.rs
+++ b/src/unit_tests/rules/cost.rs
@@ -48,4 +48,3 @@ fn test_minimize_missing_field() {
 
     assert_eq!(cost_fn.edge_cost(&overhead, &size), 0.0);
 }
-

--- a/src/unit_tests/rules/graph.rs
+++ b/src/unit_tests/rules/graph.rs
@@ -36,7 +36,14 @@ fn test_find_shortest_path() {
     let graph = ReductionGraph::new();
     let src = ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
     let dst = ReductionGraph::variant_to_map(&MaximumSetPacking::<i32>::variant());
-    let path = graph.find_cheapest_path("MaximumIndependentSet", &src, "MaximumSetPacking", &dst, &ProblemSize::new(vec![]), &MinimizeSteps);
+    let path = graph.find_cheapest_path(
+        "MaximumIndependentSet",
+        &src,
+        "MaximumSetPacking",
+        &dst,
+        &ProblemSize::new(vec![]),
+        &MinimizeSteps,
+    );
     assert!(path.is_some());
     let path = path.unwrap();
     assert_eq!(path.len(), 1); // Direct path exists
@@ -54,7 +61,14 @@ fn test_is_to_qubo_path() {
     let graph = ReductionGraph::new();
     let src = ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
     let dst = ReductionGraph::variant_to_map(&QUBO::<f64>::variant());
-    let path = graph.find_cheapest_path("MaximumIndependentSet", &src, "QUBO", &dst, &ProblemSize::new(vec![]), &MinimizeSteps);
+    let path = graph.find_cheapest_path(
+        "MaximumIndependentSet",
+        &src,
+        "QUBO",
+        &dst,
+        &ProblemSize::new(vec![]),
+        &MinimizeSteps,
+    );
     assert!(path.is_some());
     assert_eq!(path.unwrap().len(), 1); // Direct path
 }
@@ -64,15 +78,25 @@ fn test_variant_level_paths() {
     let graph = ReductionGraph::new();
 
     // Variant-level path: MaxCut<SimpleGraph, i32> -> SpinGlass<SimpleGraph, i32>
-    let src = ReductionGraph::variant_to_map(&crate::models::graph::MaxCut::<SimpleGraph, i32>::variant());
-    let dst = ReductionGraph::variant_to_map(&crate::models::optimization::SpinGlass::<SimpleGraph, i32>::variant());
+    let src = ReductionGraph::variant_to_map(
+        &crate::models::graph::MaxCut::<SimpleGraph, i32>::variant(),
+    );
+    let dst = ReductionGraph::variant_to_map(&crate::models::optimization::SpinGlass::<
+        SimpleGraph,
+        i32,
+    >::variant());
     let paths = graph.find_all_paths("MaxCut", &src, "SpinGlass", &dst);
     assert!(!paths.is_empty());
     assert_eq!(paths[0].type_names(), vec!["MaxCut", "SpinGlass"]);
 
     // Unregistered variant pair returns no paths
-    let src_f64 = ReductionGraph::variant_to_map(&crate::models::graph::MaxCut::<SimpleGraph, f64>::variant());
-    let dst_f64 = ReductionGraph::variant_to_map(&crate::models::optimization::SpinGlass::<SimpleGraph, f64>::variant());
+    let src_f64 = ReductionGraph::variant_to_map(
+        &crate::models::graph::MaxCut::<SimpleGraph, f64>::variant(),
+    );
+    let dst_f64 = ReductionGraph::variant_to_map(&crate::models::optimization::SpinGlass::<
+        SimpleGraph,
+        f64,
+    >::variant());
     let paths_f64 = graph.find_all_paths("MaxCut", &src_f64, "SpinGlass", &dst_f64);
     // No direct MaxCut<f64> -> SpinGlass<f64> reduction registered
     assert!(paths_f64.is_empty());
@@ -82,15 +106,37 @@ fn test_variant_level_paths() {
 fn test_find_shortest_path_variants() {
     let graph = ReductionGraph::new();
 
-    let src = ReductionGraph::variant_to_map(&crate::models::graph::MaxCut::<SimpleGraph, i32>::variant());
-    let dst = ReductionGraph::variant_to_map(&crate::models::optimization::SpinGlass::<SimpleGraph, i32>::variant());
-    let shortest = graph.find_cheapest_path("MaxCut", &src, "SpinGlass", &dst, &ProblemSize::new(vec![]), &MinimizeSteps);
+    let src = ReductionGraph::variant_to_map(
+        &crate::models::graph::MaxCut::<SimpleGraph, i32>::variant(),
+    );
+    let dst = ReductionGraph::variant_to_map(&crate::models::optimization::SpinGlass::<
+        SimpleGraph,
+        i32,
+    >::variant());
+    let shortest = graph.find_cheapest_path(
+        "MaxCut",
+        &src,
+        "SpinGlass",
+        &dst,
+        &ProblemSize::new(vec![]),
+        &MinimizeSteps,
+    );
     assert!(shortest.is_some());
     assert_eq!(shortest.unwrap().len(), 1); // Direct path
 
     let src = ReductionGraph::variant_to_map(&crate::models::specialized::Factoring::variant());
-    let dst = ReductionGraph::variant_to_map(&crate::models::optimization::SpinGlass::<SimpleGraph, i32>::variant());
-    let shortest = graph.find_cheapest_path("Factoring", &src, "SpinGlass", &dst, &ProblemSize::new(vec![]), &MinimizeSteps);
+    let dst = ReductionGraph::variant_to_map(&crate::models::optimization::SpinGlass::<
+        SimpleGraph,
+        i32,
+    >::variant());
+    let shortest = graph.find_cheapest_path(
+        "Factoring",
+        &src,
+        "SpinGlass",
+        &dst,
+        &ProblemSize::new(vec![]),
+        &MinimizeSteps,
+    );
     assert!(shortest.is_some());
     assert_eq!(shortest.unwrap().len(), 2); // Factoring -> CircuitSAT -> SpinGlass
 }
@@ -119,7 +165,14 @@ fn test_reduction_path_methods() {
     let src = ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
     let dst = ReductionGraph::variant_to_map(&MinimumVertexCover::<SimpleGraph, i32>::variant());
     let path = graph
-        .find_cheapest_path("MaximumIndependentSet", &src, "MinimumVertexCover", &dst, &ProblemSize::new(vec![]), &MinimizeSteps)
+        .find_cheapest_path(
+            "MaximumIndependentSet",
+            &src,
+            "MinimumVertexCover",
+            &dst,
+            &ProblemSize::new(vec![]),
+            &MinimizeSteps,
+        )
         .unwrap();
 
     assert!(!path.is_empty());
@@ -130,15 +183,26 @@ fn test_reduction_path_methods() {
 #[test]
 fn test_bidirectional_paths() {
     let graph = ReductionGraph::new();
-    let is_var = ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
+    let is_var =
+        ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
     let vc_var = ReductionGraph::variant_to_map(&MinimumVertexCover::<SimpleGraph, i32>::variant());
 
     // Forward path
-    let forward = graph.find_all_paths("MaximumIndependentSet", &is_var, "MinimumVertexCover", &vc_var);
+    let forward = graph.find_all_paths(
+        "MaximumIndependentSet",
+        &is_var,
+        "MinimumVertexCover",
+        &vc_var,
+    );
     assert!(!forward.is_empty());
 
     // Backward path
-    let backward = graph.find_all_paths("MinimumVertexCover", &vc_var, "MaximumIndependentSet", &is_var);
+    let backward = graph.find_all_paths(
+        "MinimumVertexCover",
+        &vc_var,
+        "MaximumIndependentSet",
+        &is_var,
+    );
     assert!(!backward.is_empty());
 }
 
@@ -278,7 +342,16 @@ fn test_circuit_reductions() {
     let dst = ReductionGraph::variant_to_map(&SpinGlass::<SimpleGraph, i32>::variant());
     let paths = graph.find_all_paths("Factoring", &src, "SpinGlass", &dst);
     assert!(!paths.is_empty());
-    let shortest = graph.find_cheapest_path("Factoring", &src, "SpinGlass", &dst, &ProblemSize::new(vec![]), &MinimizeSteps).unwrap();
+    let shortest = graph
+        .find_cheapest_path(
+            "Factoring",
+            &src,
+            "SpinGlass",
+            &dst,
+            &ProblemSize::new(vec![]),
+            &MinimizeSteps,
+        )
+        .unwrap();
     assert_eq!(shortest.len(), 2); // Factoring -> CircuitSAT -> SpinGlass
 }
 
@@ -388,7 +461,8 @@ fn test_to_json_file() {
 fn test_unknown_name_returns_empty() {
     let graph = ReductionGraph::new();
     let unknown = BTreeMap::new();
-    let is_var = ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
+    let is_var =
+        ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
 
     // Unknown source
     assert!(!graph.has_direct_reduction_by_name("UnknownProblem", "MaximumIndependentSet"));
@@ -407,7 +481,14 @@ fn test_unknown_name_returns_empty() {
 
     // find_shortest_path with unknown name
     assert!(graph
-        .find_cheapest_path("UnknownProblem", &unknown, "MaximumIndependentSet", &is_var, &ProblemSize::new(vec![]), &MinimizeSteps)
+        .find_cheapest_path(
+            "UnknownProblem",
+            &unknown,
+            "MaximumIndependentSet",
+            &is_var,
+            &ProblemSize::new(vec![]),
+            &MinimizeSteps
+        )
         .is_none());
 }
 
@@ -589,7 +670,7 @@ fn test_edges_have_doc_paths() {
 fn test_find_cheapest_path_minimize_steps() {
     let graph = ReductionGraph::new();
     let cost_fn = MinimizeSteps;
-    let input_size = crate::types::ProblemSize::new(vec![("n", 10), ("m", 20)]);
+    let input_size = crate::types::ProblemSize::new(vec![("num_vertices", 10), ("num_edges", 20)]);
     let src = ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
     let dst = ReductionGraph::variant_to_map(&MinimumVertexCover::<SimpleGraph, i32>::variant());
 
@@ -633,7 +714,7 @@ fn test_find_cheapest_path_multi_step() {
 fn test_find_cheapest_path_is_to_qubo() {
     let graph = ReductionGraph::new();
     let cost_fn = MinimizeSteps;
-    let input_size = crate::types::ProblemSize::new(vec![("n", 10)]);
+    let input_size = crate::types::ProblemSize::new(vec![("num_vertices", 10), ("num_edges", 20)]);
     let src = ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
     let dst = ReductionGraph::variant_to_map(&QUBO::<f64>::variant());
 
@@ -654,7 +735,7 @@ fn test_find_cheapest_path_is_to_qubo() {
 fn test_find_cheapest_path_unknown_source() {
     let graph = ReductionGraph::new();
     let cost_fn = MinimizeSteps;
-    let input_size = crate::types::ProblemSize::new(vec![("n", 10)]);
+    let input_size = crate::types::ProblemSize::new(vec![]);
     let unknown = BTreeMap::new();
     let dst = ReductionGraph::variant_to_map(&MinimumVertexCover::<SimpleGraph, i32>::variant());
 
@@ -674,7 +755,7 @@ fn test_find_cheapest_path_unknown_source() {
 fn test_find_cheapest_path_unknown_target() {
     let graph = ReductionGraph::new();
     let cost_fn = MinimizeSteps;
-    let input_size = crate::types::ProblemSize::new(vec![("n", 10)]);
+    let input_size = crate::types::ProblemSize::new(vec![("num_vertices", 10), ("num_edges", 20)]);
     let src = ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
     let unknown = BTreeMap::new();
 
@@ -717,7 +798,14 @@ fn test_make_executable_direct() {
     let src = ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
     let dst = ReductionGraph::variant_to_map(&MinimumVertexCover::<SimpleGraph, i32>::variant());
     let rpath = graph
-        .find_cheapest_path("MaximumIndependentSet", &src, "MinimumVertexCover", &dst, &ProblemSize::new(vec![]), &MinimizeSteps)
+        .find_cheapest_path(
+            "MaximumIndependentSet",
+            &src,
+            "MinimumVertexCover",
+            &dst,
+            &ProblemSize::new(vec![]),
+            &MinimizeSteps,
+        )
         .unwrap();
     let path = graph.make_executable::<
         MaximumIndependentSet<SimpleGraph, i32>,
@@ -735,7 +823,14 @@ fn test_chained_reduction_direct() {
     let src = ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
     let dst = ReductionGraph::variant_to_map(&MinimumVertexCover::<SimpleGraph, i32>::variant());
     let rpath = graph
-        .find_cheapest_path("MaximumIndependentSet", &src, "MinimumVertexCover", &dst, &ProblemSize::new(vec![]), &MinimizeSteps)
+        .find_cheapest_path(
+            "MaximumIndependentSet",
+            &src,
+            "MinimumVertexCover",
+            &dst,
+            &ProblemSize::new(vec![]),
+            &MinimizeSteps,
+        )
         .unwrap();
     let path = graph
         .make_executable::<
@@ -744,7 +839,10 @@ fn test_chained_reduction_direct() {
         >(&rpath)
         .unwrap();
 
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+    let problem = MaximumIndependentSet::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1i32; 4],
+    );
     let reduction = path.reduce(&problem);
     let target = reduction.target_problem();
 
@@ -764,16 +862,23 @@ fn test_chained_reduction_multi_step() {
     let src = ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
     let dst = ReductionGraph::variant_to_map(&MaximumSetPacking::<i32>::variant());
     let rpath = graph
-        .find_cheapest_path("MaximumIndependentSet", &src, "MaximumSetPacking", &dst, &ProblemSize::new(vec![]), &MinimizeSteps)
+        .find_cheapest_path(
+            "MaximumIndependentSet",
+            &src,
+            "MaximumSetPacking",
+            &dst,
+            &ProblemSize::new(vec![]),
+            &MinimizeSteps,
+        )
         .unwrap();
     let path = graph
-        .make_executable::<
-            MaximumIndependentSet<SimpleGraph, i32>,
-            MaximumSetPacking<i32>,
-        >(&rpath)
+        .make_executable::<MaximumIndependentSet<SimpleGraph, i32>, MaximumSetPacking<i32>>(&rpath)
         .unwrap();
 
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+    let problem = MaximumIndependentSet::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1i32; 4],
+    );
     let reduction = path.reduce(&problem);
     let target = reduction.target_problem();
 
@@ -797,11 +902,15 @@ fn test_chained_reduction_with_variant_casts() {
 
     // MIS<UnitDiskGraph, i32> -> MIS<SimpleGraph, i32> (variant cast) -> MVC<SimpleGraph, i32>
     // Use find_cheapest_path for exact variant matching (not name-based)
-    let src_var = ReductionGraph::variant_to_map(&MaximumIndependentSet::<UnitDiskGraph, i32>::variant());
-    let dst_var = ReductionGraph::variant_to_map(&MinimumVertexCover::<SimpleGraph, i32>::variant());
+    let src_var =
+        ReductionGraph::variant_to_map(&MaximumIndependentSet::<UnitDiskGraph, i32>::variant());
+    let dst_var =
+        ReductionGraph::variant_to_map(&MinimumVertexCover::<SimpleGraph, i32>::variant());
     let rpath = graph.find_cheapest_path(
-        "MaximumIndependentSet", &src_var,
-        "MinimumVertexCover", &dst_var,
+        "MaximumIndependentSet",
+        &src_var,
+        "MinimumVertexCover",
+        &dst_var,
         &ProblemSize::new(vec![]),
         &MinimizeSteps,
     );
@@ -838,11 +947,15 @@ fn test_chained_reduction_with_variant_casts() {
     // Also test the KSat<K3> -> Sat -> MIS multi-step path
     // Use find_cheapest_path for exact variant matching (not name-based
     // and may pick a path through a different KSat variant)
-    let ksat_src = ReductionGraph::variant_to_map(&KSatisfiability::<crate::variant::K3>::variant());
-    let ksat_dst = ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
+    let ksat_src =
+        ReductionGraph::variant_to_map(&KSatisfiability::<crate::variant::K3>::variant());
+    let ksat_dst =
+        ReductionGraph::variant_to_map(&MaximumIndependentSet::<SimpleGraph, i32>::variant());
     let ksat_rpath = graph.find_cheapest_path(
-        "KSatisfiability", &ksat_src,
-        "MaximumIndependentSet", &ksat_dst,
+        "KSatisfiability",
+        &ksat_src,
+        "MaximumIndependentSet",
+        &ksat_dst,
         &crate::types::ProblemSize::new(vec![]),
         &crate::rules::MinimizeSteps,
     );

--- a/src/unit_tests/rules/maximumclique_ilp.rs
+++ b/src/unit_tests/rules/maximumclique_ilp.rs
@@ -52,8 +52,10 @@ fn brute_force_max_clique(problem: &MaximumClique<SimpleGraph, i32>) -> i32 {
 fn test_reduction_creates_valid_ilp() {
     // Triangle graph: 3 vertices, 3 edges (complete graph K3)
     // All pairs are adjacent, so no constraints should be added
-    let problem: MaximumClique<SimpleGraph, i32> =
-        MaximumClique::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1; 3]);
+    let problem: MaximumClique<SimpleGraph, i32> = MaximumClique::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![1; 3],
+    );
     let reduction: ReductionCliqueToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -75,7 +77,8 @@ fn test_reduction_creates_valid_ilp() {
 #[test]
 fn test_reduction_with_non_edges() {
     // Path graph 0-1-2: edges (0,1) and (1,2), non-edge (0,2)
-    let problem: MaximumClique<SimpleGraph, i32> = MaximumClique::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1; 3]);
+    let problem: MaximumClique<SimpleGraph, i32> =
+        MaximumClique::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1; 3]);
     let reduction: ReductionCliqueToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -108,8 +111,10 @@ fn test_reduction_weighted() {
 #[test]
 fn test_ilp_solution_equals_brute_force_triangle() {
     // Triangle graph (K3): max clique = 3 vertices
-    let problem: MaximumClique<SimpleGraph, i32> =
-        MaximumClique::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1; 3]);
+    let problem: MaximumClique<SimpleGraph, i32> = MaximumClique::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![1; 3],
+    );
     let reduction: ReductionCliqueToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -137,8 +142,10 @@ fn test_ilp_solution_equals_brute_force_triangle() {
 #[test]
 fn test_ilp_solution_equals_brute_force_path() {
     // Path graph 0-1-2-3: max clique = 2 (any adjacent pair)
-    let problem: MaximumClique<SimpleGraph, i32> =
-        MaximumClique::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1; 4]);
+    let problem: MaximumClique<SimpleGraph, i32> = MaximumClique::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1; 4],
+    );
     let reduction: ReductionCliqueToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -187,7 +194,8 @@ fn test_ilp_solution_equals_brute_force_weighted() {
 
 #[test]
 fn test_solution_extraction() {
-    let problem: MaximumClique<SimpleGraph, i32> = MaximumClique::new(SimpleGraph::new(4, vec![(0, 1), (2, 3)]), vec![1; 4]);
+    let problem: MaximumClique<SimpleGraph, i32> =
+        MaximumClique::new(SimpleGraph::new(4, vec![(0, 1), (2, 3)]), vec![1; 4]);
     let reduction: ReductionCliqueToILP = ReduceTo::<ILP>::reduce_to(&problem);
 
     // Test that extraction works correctly (1:1 mapping)
@@ -201,8 +209,10 @@ fn test_solution_extraction() {
 
 #[test]
 fn test_ilp_structure() {
-    let problem: MaximumClique<SimpleGraph, i32> =
-        MaximumClique::new(SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]), vec![1; 5]);
+    let problem: MaximumClique<SimpleGraph, i32> = MaximumClique::new(
+        SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+        vec![1; 5],
+    );
     let reduction: ReductionCliqueToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -214,7 +224,8 @@ fn test_ilp_structure() {
 #[test]
 fn test_empty_graph() {
     // Graph with no edges: max clique = 1 (any single vertex)
-    let problem: MaximumClique<SimpleGraph, i32> = MaximumClique::new(SimpleGraph::new(3, vec![]), vec![1; 3]);
+    let problem: MaximumClique<SimpleGraph, i32> =
+        MaximumClique::new(SimpleGraph::new(3, vec![]), vec![1; 3]);
     let reduction: ReductionCliqueToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -235,8 +246,10 @@ fn test_empty_graph() {
 #[test]
 fn test_complete_graph() {
     // Complete graph K4: max clique = 4 (all vertices)
-    let problem: MaximumClique<SimpleGraph, i32> =
-        MaximumClique::new(SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]), vec![1; 4]);
+    let problem: MaximumClique<SimpleGraph, i32> = MaximumClique::new(
+        SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]),
+        vec![1; 4],
+    );
     let reduction: ReductionCliqueToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -258,8 +271,10 @@ fn test_complete_graph() {
 fn test_bipartite_graph() {
     // Bipartite graph: 0-2, 0-3, 1-2, 1-3 (two independent sets: {0,1} and {2,3})
     // Max clique = 2 (any edge, e.g., {0, 2})
-    let problem: MaximumClique<SimpleGraph, i32> =
-        MaximumClique::new(SimpleGraph::new(4, vec![(0, 2), (0, 3), (1, 2), (1, 3)]), vec![1; 4]);
+    let problem: MaximumClique<SimpleGraph, i32> = MaximumClique::new(
+        SimpleGraph::new(4, vec![(0, 2), (0, 3), (1, 2), (1, 3)]),
+        vec![1; 4],
+    );
     let reduction: ReductionCliqueToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -279,8 +294,10 @@ fn test_bipartite_graph() {
 fn test_star_graph() {
     // Star graph: center 0 connected to 1, 2, 3
     // Max clique = 2 (center + any leaf)
-    let problem: MaximumClique<SimpleGraph, i32> =
-        MaximumClique::new(SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]), vec![1; 4]);
+    let problem: MaximumClique<SimpleGraph, i32> = MaximumClique::new(
+        SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]),
+        vec![1; 4],
+    );
     let reduction: ReductionCliqueToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 

--- a/src/unit_tests/rules/maximumindependentset_gridgraph.rs
+++ b/src/unit_tests/rules/maximumindependentset_gridgraph.rs
@@ -6,7 +6,10 @@ use crate::topology::{Graph, KingsSubgraph, SimpleGraph, UnitDiskGraph};
 #[test]
 fn test_mis_simple_to_grid_closed_loop() {
     // Triangle graph: 3 vertices, 3 edges
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+    let problem = MaximumIndependentSet::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![1i32; 3],
+    );
     let result = ReduceTo::<MaximumIndependentSet<KingsSubgraph, i32>>::reduce_to(&problem);
     let target = result.target_problem();
 
@@ -30,7 +33,8 @@ fn test_mis_simple_to_grid_closed_loop() {
 #[test]
 fn test_mis_simple_to_grid_path_graph() {
     // Path graph: 0-1-2
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+    let problem =
+        MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
     let result = ReduceTo::<MaximumIndependentSet<KingsSubgraph, i32>>::reduce_to(&problem);
     let target = result.target_problem();
 

--- a/src/unit_tests/rules/maximumindependentset_ilp.rs
+++ b/src/unit_tests/rules/maximumindependentset_ilp.rs
@@ -6,7 +6,10 @@ use crate::types::SolutionSize;
 #[test]
 fn test_reduction_creates_valid_ilp() {
     // Triangle graph: 3 vertices, 3 edges
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+    let problem = MaximumIndependentSet::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![1i32; 3],
+    );
     let reduction: ReductionISToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -50,7 +53,10 @@ fn test_reduction_weighted() {
 #[test]
 fn test_ilp_solution_equals_brute_force_triangle() {
     // Triangle graph: max IS = 1 vertex
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+    let problem = MaximumIndependentSet::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![1i32; 3],
+    );
     let reduction: ReductionISToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -80,7 +86,10 @@ fn test_ilp_solution_equals_brute_force_triangle() {
 #[test]
 fn test_ilp_solution_equals_brute_force_path() {
     // Path graph 0-1-2-3: max IS = 2 (e.g., {0, 2} or {1, 3} or {0, 3})
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+    let problem = MaximumIndependentSet::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1i32; 4],
+    );
     let reduction: ReductionISToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -109,7 +118,8 @@ fn test_ilp_solution_equals_brute_force_weighted() {
     // 0 -- 1 -- 2
     // Weights: [1, 100, 1]
     // Max IS by weight: just vertex 1 (weight 100) beats 0+2 (weight 2)
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1, 100, 1]);
+    let problem =
+        MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1, 100, 1]);
     let reduction: ReductionISToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -132,7 +142,8 @@ fn test_ilp_solution_equals_brute_force_weighted() {
 
 #[test]
 fn test_solution_extraction() {
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (2, 3)]), vec![1i32; 4]);
+    let problem =
+        MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (2, 3)]), vec![1i32; 4]);
     let reduction: ReductionISToILP = ReduceTo::<ILP>::reduce_to(&problem);
 
     // Test that extraction works correctly (1:1 mapping)
@@ -146,8 +157,10 @@ fn test_solution_extraction() {
 
 #[test]
 fn test_ilp_structure() {
-    let problem =
-        MaximumIndependentSet::new(SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]), vec![1i32; 5]);
+    let problem = MaximumIndependentSet::new(
+        SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+        vec![1i32; 5],
+    );
     let reduction: ReductionISToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -198,7 +211,10 @@ fn test_complete_graph() {
 #[test]
 fn test_solve_reduced() {
     // Test the ILPSolver::solve_reduced method
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+    let problem = MaximumIndependentSet::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1i32; 4],
+    );
 
     let ilp_solver = ILPSolver::new();
     let solution = ilp_solver
@@ -213,8 +229,10 @@ fn test_solve_reduced() {
 fn test_bipartite_graph() {
     // Bipartite graph: 0-2, 0-3, 1-2, 1-3 (two independent sets: {0,1} and {2,3})
     // With equal weights, max IS = 2
-    let problem =
-        MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 2), (0, 3), (1, 2), (1, 3)]), vec![1i32; 4]);
+    let problem = MaximumIndependentSet::new(
+        SimpleGraph::new(4, vec![(0, 2), (0, 3), (1, 2), (1, 3)]),
+        vec![1i32; 4],
+    );
     let reduction: ReductionISToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 

--- a/src/unit_tests/rules/maximumindependentset_maximumsetpacking.rs
+++ b/src/unit_tests/rules/maximumindependentset_maximumsetpacking.rs
@@ -4,7 +4,8 @@ include!("../jl_helpers.rs");
 
 #[test]
 fn test_weighted_reduction() {
-    let is_problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![10, 20, 30]);
+    let is_problem =
+        MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![10, 20, 30]);
     let reduction = ReduceTo::<MaximumSetPacking<i32>>::reduce_to(&is_problem);
     let sp_problem = reduction.target_problem();
 
@@ -45,7 +46,8 @@ fn test_disjoint_sets() {
 #[test]
 fn test_reduction_structure() {
     // Test IS to SP structure
-    let is_problem = MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2)]), vec![1i32; 4]);
+    let is_problem =
+        MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2)]), vec![1i32; 4]);
     let reduction = ReduceTo::<MaximumSetPacking<i32>>::reduce_to(&is_problem);
     let sp = reduction.target_problem();
 
@@ -73,10 +75,8 @@ fn test_jl_parity_is_to_setpacking() {
         serde_json::from_str(include_str!("../../../tests/data/jl/independentset.json")).unwrap();
     let inst = &is_data["instances"][0]["instance"];
     let nv = inst["num_vertices"].as_u64().unwrap() as usize;
-    let source = MaximumIndependentSet::new(
-        SimpleGraph::new(nv, jl_parse_edges(inst)),
-        vec![1i32; nv],
-    );
+    let source =
+        MaximumIndependentSet::new(SimpleGraph::new(nv, jl_parse_edges(inst)), vec![1i32; nv]);
     let result = ReduceTo::<MaximumSetPacking<i32>>::reduce_to(&source);
     let solver = BruteForce::new();
     let best_target = solver.find_all_best(result.target_problem());
@@ -125,10 +125,8 @@ fn test_jl_parity_rule_is_to_setpacking() {
         serde_json::from_str(include_str!("../../../tests/data/jl/independentset.json")).unwrap();
     let inst = &jl_find_instance_by_label(&is_data, "doc_4vertex")["instance"];
     let nv = inst["num_vertices"].as_u64().unwrap() as usize;
-    let source = MaximumIndependentSet::new(
-        SimpleGraph::new(nv, jl_parse_edges(inst)),
-        vec![1i32; nv],
-    );
+    let source =
+        MaximumIndependentSet::new(SimpleGraph::new(nv, jl_parse_edges(inst)), vec![1i32; nv]);
     let result = ReduceTo::<MaximumSetPacking<i32>>::reduce_to(&source);
     let solver = BruteForce::new();
     let best_target = solver.find_all_best(result.target_problem());
@@ -154,10 +152,8 @@ fn test_jl_parity_doc_is_to_setpacking() {
     let is_instance = jl_find_instance_by_label(&is_data, "doc_4vertex");
     let inst = &is_instance["instance"];
     let nv = inst["num_vertices"].as_u64().unwrap() as usize;
-    let source = MaximumIndependentSet::new(
-        SimpleGraph::new(nv, jl_parse_edges(inst)),
-        vec![1i32; nv],
-    );
+    let source =
+        MaximumIndependentSet::new(SimpleGraph::new(nv, jl_parse_edges(inst)), vec![1i32; nv]);
     let result = ReduceTo::<MaximumSetPacking<i32>>::reduce_to(&source);
     let solver = BruteForce::new();
     let best_target = solver.find_all_best(result.target_problem());

--- a/src/unit_tests/rules/maximumindependentset_qubo.rs
+++ b/src/unit_tests/rules/maximumindependentset_qubo.rs
@@ -6,7 +6,10 @@ use crate::traits::Problem;
 fn test_independentset_to_qubo_closed_loop() {
     // Path graph: 0-1-2-3 (4 vertices, 3 edges)
     // Maximum IS = {0, 2} or {1, 3} (size 2)
-    let is = MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+    let is = MaximumIndependentSet::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1i32; 4],
+    );
     let reduction = ReduceTo::<QUBO<f64>>::reduce_to(&is);
     let qubo = reduction.target_problem();
 
@@ -24,7 +27,10 @@ fn test_independentset_to_qubo_closed_loop() {
 fn test_independentset_to_qubo_triangle() {
     // Triangle: 0-1-2 (complete graph K3)
     // Maximum IS = any single vertex (size 1)
-    let is = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+    let is = MaximumIndependentSet::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![1i32; 3],
+    );
     let reduction = ReduceTo::<QUBO<f64>>::reduce_to(&is);
     let qubo = reduction.target_problem();
 
@@ -57,7 +63,10 @@ fn test_independentset_to_qubo_empty_graph() {
 
 #[test]
 fn test_independentset_to_qubo_structure() {
-    let is = MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+    let is = MaximumIndependentSet::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1i32; 4],
+    );
     let reduction = ReduceTo::<QUBO<f64>>::reduce_to(&is);
     let qubo = reduction.target_problem();
 

--- a/src/unit_tests/rules/maximumindependentset_triangular.rs
+++ b/src/unit_tests/rules/maximumindependentset_triangular.rs
@@ -5,7 +5,8 @@ use crate::topology::{Graph, SimpleGraph, TriangularSubgraph};
 #[test]
 fn test_mis_simple_to_triangular_closed_loop() {
     // Path graph: 0-1-2
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+    let problem =
+        MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
     let result = ReduceTo::<MaximumIndependentSet<TriangularSubgraph, i32>>::reduce_to(&problem);
     let target = result.target_problem();
 

--- a/src/unit_tests/rules/maximummatching_ilp.rs
+++ b/src/unit_tests/rules/maximummatching_ilp.rs
@@ -7,7 +7,8 @@ use crate::types::SolutionSize;
 #[test]
 fn test_reduction_creates_valid_ilp() {
     // Triangle graph: 3 vertices, 3 edges
-    let problem = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]));
+    let problem =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]));
     let reduction: ReductionMatchingToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -50,7 +51,8 @@ fn test_reduction_weighted() {
 #[test]
 fn test_ilp_solution_equals_brute_force_triangle() {
     // Triangle graph: max matching = 1 edge
-    let problem = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]));
+    let problem =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]));
     let reduction: ReductionMatchingToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -80,7 +82,8 @@ fn test_ilp_solution_equals_brute_force_triangle() {
 #[test]
 fn test_ilp_solution_equals_brute_force_path() {
     // Path graph 0-1-2-3: max matching = 2 (edges {0-1, 2-3})
-    let problem = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]));
+    let problem =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]));
     let reduction: ReductionMatchingToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -132,7 +135,8 @@ fn test_ilp_solution_equals_brute_force_weighted() {
 
 #[test]
 fn test_solution_extraction() {
-    let problem = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (2, 3)]));
+    let problem =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (2, 3)]));
     let reduction: ReductionMatchingToILP = ReduceTo::<ILP>::reduce_to(&problem);
 
     // Test that extraction works correctly (1:1 mapping)
@@ -146,8 +150,10 @@ fn test_solution_extraction() {
 
 #[test]
 fn test_ilp_structure() {
-    let problem =
-        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]));
+    let problem = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(
+        5,
+        vec![(0, 1), (1, 2), (2, 3), (3, 4)],
+    ));
     let reduction: ReductionMatchingToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -174,9 +180,10 @@ fn test_empty_graph() {
 #[test]
 fn test_k4_perfect_matching() {
     // Complete graph K4: can have perfect matching (2 edges covering all 4 vertices)
-    let problem = MaximumMatching::<_, i32>::unit_weights(
-        SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]),
-    );
+    let problem = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(
+        4,
+        vec![(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)],
+    ));
     let reduction: ReductionMatchingToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -200,7 +207,8 @@ fn test_k4_perfect_matching() {
 fn test_star_graph() {
     // Star graph with center vertex 0 connected to 1, 2, 3
     // Max matching = 1 (only one edge can be selected)
-    let problem = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]));
+    let problem =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]));
     let reduction: ReductionMatchingToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -216,8 +224,10 @@ fn test_star_graph() {
 fn test_bipartite_graph() {
     // Bipartite graph: {0,1} and {2,3} with all cross edges
     // Max matching = 2 (one perfect matching)
-    let problem =
-        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 2), (0, 3), (1, 2), (1, 3)]));
+    let problem = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(
+        4,
+        vec![(0, 2), (0, 3), (1, 2), (1, 3)],
+    ));
     let reduction: ReductionMatchingToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -232,7 +242,8 @@ fn test_bipartite_graph() {
 #[test]
 fn test_solve_reduced() {
     // Test the ILPSolver::solve_reduced method
-    let problem = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]));
+    let problem =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]));
 
     let ilp_solver = ILPSolver::new();
     let solution = ilp_solver

--- a/src/unit_tests/rules/maximummatching_maximumsetpacking.rs
+++ b/src/unit_tests/rules/maximummatching_maximumsetpacking.rs
@@ -8,7 +8,8 @@ include!("../jl_helpers.rs");
 #[test]
 fn test_matching_to_setpacking_structure() {
     // Path graph 0-1-2
-    let matching = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(3, vec![(0, 1), (1, 2)]));
+    let matching =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(3, vec![(0, 1), (1, 2)]));
     let reduction = ReduceTo::<MaximumSetPacking<i32>>::reduce_to(&matching);
     let sp = reduction.target_problem();
 
@@ -24,8 +25,10 @@ fn test_matching_to_setpacking_structure() {
 #[test]
 fn test_matching_to_setpacking_weighted() {
     // Weighted edges: heavy edge should win over multiple light edges
-    let matching =
-        MaximumMatching::new(SimpleGraph::new(4, vec![(0, 1), (0, 2), (1, 3)]), vec![100, 1, 1]);
+    let matching = MaximumMatching::new(
+        SimpleGraph::new(4, vec![(0, 1), (0, 2), (1, 3)]),
+        vec![100, 1, 1],
+    );
     let reduction = ReduceTo::<MaximumSetPacking<i32>>::reduce_to(&matching);
     let sp = reduction.target_problem();
 
@@ -52,7 +55,8 @@ fn test_matching_to_setpacking_weighted() {
 
 #[test]
 fn test_matching_to_setpacking_solution_extraction() {
-    let matching = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]));
+    let matching =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]));
     let reduction = ReduceTo::<MaximumSetPacking<i32>>::reduce_to(&matching);
 
     // Test solution extraction is 1:1
@@ -93,7 +97,8 @@ fn test_matching_to_setpacking_single_edge() {
 #[test]
 fn test_matching_to_setpacking_disjoint_edges() {
     // Two disjoint edges: 0-1 and 2-3
-    let matching = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (2, 3)]));
+    let matching =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (2, 3)]));
     let reduction = ReduceTo::<MaximumSetPacking<i32>>::reduce_to(&matching);
     let sp = reduction.target_problem();
 
@@ -106,7 +111,8 @@ fn test_matching_to_setpacking_disjoint_edges() {
 
 #[test]
 fn test_reduction_structure() {
-    let matching = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3)]));
+    let matching =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3)]));
     let reduction = ReduceTo::<MaximumSetPacking<i32>>::reduce_to(&matching);
     let sp = reduction.target_problem();
 
@@ -117,7 +123,8 @@ fn test_reduction_structure() {
 #[test]
 fn test_matching_to_setpacking_star() {
     // Star graph: center vertex 0 connected to 1, 2, 3
-    let matching = MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]));
+    let matching =
+        MaximumMatching::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]));
     let reduction = ReduceTo::<MaximumSetPacking<i32>>::reduce_to(&matching);
     let sp = reduction.target_problem();
 

--- a/src/unit_tests/rules/minimumdominatingset_ilp.rs
+++ b/src/unit_tests/rules/minimumdominatingset_ilp.rs
@@ -6,7 +6,10 @@ use crate::types::SolutionSize;
 #[test]
 fn test_reduction_creates_valid_ilp() {
     // Triangle graph: 3 vertices, 3 edges
-    let problem = MinimumDominatingSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+    let problem = MinimumDominatingSet::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![1i32; 3],
+    );
     let reduction: ReductionDSToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -51,7 +54,10 @@ fn test_reduction_weighted() {
 fn test_ilp_solution_equals_brute_force_star() {
     // Star graph: center vertex 0 connected to all others
     // Minimum dominating set is just the center (weight 1)
-    let problem = MinimumDominatingSet::new(SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]), vec![1i32; 4]);
+    let problem = MinimumDominatingSet::new(
+        SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]),
+        vec![1i32; 4],
+    );
     let reduction: ReductionDSToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -81,8 +87,10 @@ fn test_ilp_solution_equals_brute_force_star() {
 #[test]
 fn test_ilp_solution_equals_brute_force_path() {
     // Path graph 0-1-2-3-4: min DS = 2 (e.g., vertices 1 and 3)
-    let problem =
-        MinimumDominatingSet::new(SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]), vec![1i32; 5]);
+    let problem = MinimumDominatingSet::new(
+        SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+        vec![1i32; 5],
+    );
     let reduction: ReductionDSToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -109,8 +117,10 @@ fn test_ilp_solution_equals_brute_force_path() {
 fn test_ilp_solution_equals_brute_force_weighted() {
     // Star with heavy center: prefer selecting all leaves (total weight 3)
     // over center (weight 100)
-    let problem =
-        MinimumDominatingSet::new(SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]), vec![100, 1, 1, 1]);
+    let problem = MinimumDominatingSet::new(
+        SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]),
+        vec![100, 1, 1, 1],
+    );
     let reduction: ReductionDSToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -133,7 +143,8 @@ fn test_ilp_solution_equals_brute_force_weighted() {
 
 #[test]
 fn test_solution_extraction() {
-    let problem = MinimumDominatingSet::new(SimpleGraph::new(4, vec![(0, 1), (2, 3)]), vec![1i32; 4]);
+    let problem =
+        MinimumDominatingSet::new(SimpleGraph::new(4, vec![(0, 1), (2, 3)]), vec![1i32; 4]);
     let reduction: ReductionDSToILP = ReduceTo::<ILP>::reduce_to(&problem);
 
     // Test that extraction works correctly (1:1 mapping)
@@ -147,8 +158,10 @@ fn test_solution_extraction() {
 
 #[test]
 fn test_ilp_structure() {
-    let problem =
-        MinimumDominatingSet::new(SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]), vec![1i32; 5]);
+    let problem = MinimumDominatingSet::new(
+        SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+        vec![1i32; 5],
+    );
     let reduction: ReductionDSToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 

--- a/src/unit_tests/rules/minimumvertexcover_ilp.rs
+++ b/src/unit_tests/rules/minimumvertexcover_ilp.rs
@@ -6,7 +6,10 @@ use crate::types::SolutionSize;
 #[test]
 fn test_reduction_creates_valid_ilp() {
     // Triangle graph: 3 vertices, 3 edges
-    let problem = MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+    let problem = MinimumVertexCover::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![1i32; 3],
+    );
     let reduction: ReductionVCToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -50,7 +53,10 @@ fn test_reduction_weighted() {
 #[test]
 fn test_ilp_solution_equals_brute_force_triangle() {
     // Triangle graph: min VC = 2 vertices
-    let problem = MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+    let problem = MinimumVertexCover::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![1i32; 3],
+    );
     let reduction: ReductionVCToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -80,7 +86,10 @@ fn test_ilp_solution_equals_brute_force_triangle() {
 #[test]
 fn test_ilp_solution_equals_brute_force_path() {
     // Path graph 0-1-2-3: min VC = 2 (e.g., {1, 2} or {0, 2} or {1, 3})
-    let problem = MinimumVertexCover::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+    let problem = MinimumVertexCover::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1i32; 4],
+    );
     let reduction: ReductionVCToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -109,7 +118,8 @@ fn test_ilp_solution_equals_brute_force_weighted() {
     // 0 -- 1 -- 2
     // Weights: [100, 1, 100]
     // Min VC by weight: just vertex 1 (weight 1) beats 0+2 (weight 200)
-    let problem = MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![100, 1, 100]);
+    let problem =
+        MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![100, 1, 100]);
     let reduction: ReductionVCToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -146,8 +156,10 @@ fn test_solution_extraction() {
 
 #[test]
 fn test_ilp_structure() {
-    let problem =
-        MinimumVertexCover::new(SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]), vec![1i32; 5]);
+    let problem = MinimumVertexCover::new(
+        SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+        vec![1i32; 5],
+    );
     let reduction: ReductionVCToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -198,7 +210,10 @@ fn test_complete_graph() {
 #[test]
 fn test_solve_reduced() {
     // Test the ILPSolver::solve_reduced method
-    let problem = MinimumVertexCover::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+    let problem = MinimumVertexCover::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+        vec![1i32; 4],
+    );
 
     let ilp_solver = ILPSolver::new();
     let solution = ilp_solver
@@ -213,8 +228,10 @@ fn test_solve_reduced() {
 fn test_bipartite_graph() {
     // Bipartite graph: 0-2, 0-3, 1-2, 1-3 (complete bipartite K_{2,2})
     // Min VC = 2 (either side of the bipartition)
-    let problem =
-        MinimumVertexCover::new(SimpleGraph::new(4, vec![(0, 2), (0, 3), (1, 2), (1, 3)]), vec![1i32; 4]);
+    let problem = MinimumVertexCover::new(
+        SimpleGraph::new(4, vec![(0, 2), (0, 3), (1, 2), (1, 3)]),
+        vec![1i32; 4],
+    );
     let reduction: ReductionVCToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -255,8 +272,10 @@ fn test_single_edge() {
 fn test_star_graph() {
     // Star graph: center vertex 0 connected to all others
     // Min VC = 1 (just the center)
-    let problem =
-        MinimumVertexCover::new(SimpleGraph::new(5, vec![(0, 1), (0, 2), (0, 3), (0, 4)]), vec![1i32; 5]);
+    let problem = MinimumVertexCover::new(
+        SimpleGraph::new(5, vec![(0, 1), (0, 2), (0, 3), (0, 4)]),
+        vec![1i32; 5],
+    );
     let reduction: ReductionVCToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 

--- a/src/unit_tests/rules/minimumvertexcover_maximumindependentset.rs
+++ b/src/unit_tests/rules/minimumvertexcover_maximumindependentset.rs
@@ -5,7 +5,8 @@ include!("../jl_helpers.rs");
 #[test]
 fn test_weighted_reduction() {
     // Test with weighted problems
-    let is_problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![10, 20, 30]);
+    let is_problem =
+        MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![10, 20, 30]);
     let reduction = ReduceTo::<MinimumVertexCover<SimpleGraph, i32>>::reduce_to(&is_problem);
     let vc_problem = reduction.target_problem();
 
@@ -15,8 +16,10 @@ fn test_weighted_reduction() {
 
 #[test]
 fn test_reduction_structure() {
-    let is_problem =
-        MaximumIndependentSet::new(SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]), vec![1i32; 5]);
+    let is_problem = MaximumIndependentSet::new(
+        SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+        vec![1i32; 5],
+    );
     let reduction = ReduceTo::<MinimumVertexCover<SimpleGraph, i32>>::reduce_to(&is_problem);
     let vc = reduction.target_problem();
 
@@ -34,10 +37,8 @@ fn test_jl_parity_is_to_vertexcovering() {
         serde_json::from_str(include_str!("../../../tests/data/jl/independentset.json")).unwrap();
     let inst = &is_data["instances"][0]["instance"];
     let nv = inst["num_vertices"].as_u64().unwrap() as usize;
-    let source = MaximumIndependentSet::new(
-        SimpleGraph::new(nv, jl_parse_edges(inst)),
-        vec![1i32; nv],
-    );
+    let source =
+        MaximumIndependentSet::new(SimpleGraph::new(nv, jl_parse_edges(inst)), vec![1i32; nv]);
     let result = ReduceTo::<MinimumVertexCover<SimpleGraph, i32>>::reduce_to(&source);
     let solver = BruteForce::new();
     let best_target = solver.find_all_best(result.target_problem());
@@ -62,10 +63,8 @@ fn test_jl_parity_rule_is_to_vertexcovering() {
         serde_json::from_str(include_str!("../../../tests/data/jl/independentset.json")).unwrap();
     let inst = &jl_find_instance_by_label(&is_data, "doc_4vertex")["instance"];
     let nv = inst["num_vertices"].as_u64().unwrap() as usize;
-    let source = MaximumIndependentSet::new(
-        SimpleGraph::new(nv, jl_parse_edges(inst)),
-        vec![1i32; nv],
-    );
+    let source =
+        MaximumIndependentSet::new(SimpleGraph::new(nv, jl_parse_edges(inst)), vec![1i32; nv]);
     let result = ReduceTo::<MinimumVertexCover<SimpleGraph, i32>>::reduce_to(&source);
     let solver = BruteForce::new();
     let best_target = solver.find_all_best(result.target_problem());

--- a/src/unit_tests/rules/minimumvertexcover_minimumsetcovering.rs
+++ b/src/unit_tests/rules/minimumvertexcover_minimumsetcovering.rs
@@ -8,7 +8,8 @@ fn test_vc_to_sc_basic() {
     // Vertex 0 covers edge 0
     // Vertex 1 covers edges 0 and 1
     // Vertex 2 covers edge 1
-    let vc_problem = MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+    let vc_problem =
+        MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
     let reduction = ReduceTo::<MinimumSetCovering<i32>>::reduce_to(&vc_problem);
     let sc_problem = reduction.target_problem();
 
@@ -28,7 +29,10 @@ fn test_vc_to_sc_basic() {
 fn test_vc_to_sc_triangle() {
     // Triangle graph: 3 vertices, 3 edges
     // Edge indices: (0,1)->0, (1,2)->1, (0,2)->2
-    let vc_problem = MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+    let vc_problem = MinimumVertexCover::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![1i32; 3],
+    );
     let reduction = ReduceTo::<MinimumSetCovering<i32>>::reduce_to(&vc_problem);
     let sc_problem = reduction.target_problem();
 
@@ -45,7 +49,8 @@ fn test_vc_to_sc_triangle() {
 #[test]
 fn test_vc_to_sc_weighted() {
     // Weighted problem: weights should be preserved
-    let vc_problem = MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![10, 1, 10]);
+    let vc_problem =
+        MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![10, 1, 10]);
     let reduction = ReduceTo::<MinimumSetCovering<i32>>::reduce_to(&vc_problem);
     let sc_problem = reduction.target_problem();
 
@@ -82,7 +87,10 @@ fn test_vc_to_sc_empty_graph() {
 fn test_vc_to_sc_star_graph() {
     // Star graph: center vertex 0 connected to all others
     // Edges: (0,1), (0,2), (0,3)
-    let vc_problem = MinimumVertexCover::new(SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]), vec![1i32; 4]);
+    let vc_problem = MinimumVertexCover::new(
+        SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]),
+        vec![1i32; 4],
+    );
     let reduction = ReduceTo::<MinimumSetCovering<i32>>::reduce_to(&vc_problem);
     let sc_problem = reduction.target_problem();
 

--- a/src/unit_tests/rules/minimumvertexcover_qubo.rs
+++ b/src/unit_tests/rules/minimumvertexcover_qubo.rs
@@ -6,7 +6,10 @@ use crate::traits::Problem;
 fn test_vertexcovering_to_qubo_closed_loop() {
     // Cycle C4: 0-1-2-3-0 (4 vertices, 4 edges)
     // Minimum VC = 2 vertices (e.g., {0, 2} or {1, 3})
-    let vc = MinimumVertexCover::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3), (0, 3)]), vec![1i32; 4]);
+    let vc = MinimumVertexCover::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3), (0, 3)]),
+        vec![1i32; 4],
+    );
     let reduction = ReduceTo::<QUBO<f64>>::reduce_to(&vc);
     let qubo = reduction.target_problem();
 
@@ -23,7 +26,10 @@ fn test_vertexcovering_to_qubo_closed_loop() {
 #[test]
 fn test_vertexcovering_to_qubo_triangle() {
     // Triangle K3: minimum VC = 2 (any two vertices)
-    let vc = MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+    let vc = MinimumVertexCover::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![1i32; 3],
+    );
     let reduction = ReduceTo::<QUBO<f64>>::reduce_to(&vc);
     let qubo = reduction.target_problem();
 
@@ -41,7 +47,10 @@ fn test_vertexcovering_to_qubo_triangle() {
 fn test_vertexcovering_to_qubo_star() {
     // Star graph: center vertex 0 connected to 1, 2, 3
     // Minimum VC = {0} (just the center)
-    let vc = MinimumVertexCover::new(SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]), vec![1i32; 4]);
+    let vc = MinimumVertexCover::new(
+        SimpleGraph::new(4, vec![(0, 1), (0, 2), (0, 3)]),
+        vec![1i32; 4],
+    );
     let reduction = ReduceTo::<QUBO<f64>>::reduce_to(&vc);
     let qubo = reduction.target_problem();
 
@@ -57,7 +66,10 @@ fn test_vertexcovering_to_qubo_star() {
 
 #[test]
 fn test_vertexcovering_to_qubo_structure() {
-    let vc = MinimumVertexCover::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3), (0, 3)]), vec![1i32; 4]);
+    let vc = MinimumVertexCover::new(
+        SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3), (0, 3)]),
+        vec![1i32; 4],
+    );
     let reduction = ReduceTo::<QUBO<f64>>::reduce_to(&vc);
     let qubo = reduction.target_problem();
 

--- a/src/unit_tests/rules/reduction_path_parity.rs
+++ b/src/unit_tests/rules/reduction_path_parity.rs
@@ -8,7 +8,7 @@ use crate::models::specialized::Factoring;
 use crate::rules::{MinimizeSteps, ReductionGraph};
 use crate::solvers::{BruteForce, Solver};
 use crate::topology::SimpleGraph;
-use crate::traits::Problem;
+use crate::traits::{problem_size, Problem};
 use crate::types::ProblemSize;
 use std::collections::HashSet;
 
@@ -206,7 +206,7 @@ fn test_find_cheapest_path_with_problem_size() {
             &src_var,
             "SpinGlass",
             &dst_var,
-            &source.problem_size(),
+            &problem_size(&source),
             &MinimizeSteps,
         )
         .expect("Should find path MaxCut -> SpinGlass");
@@ -214,7 +214,7 @@ fn test_find_cheapest_path_with_problem_size() {
     assert!(!rpath.type_names().is_empty());
 
     // Verify problem_size has expected components
-    let size = source.problem_size();
+    let size = problem_size(&source);
     assert_eq!(size.get("num_vertices"), Some(10));
     assert_eq!(size.get("num_edges"), Some(15));
 }

--- a/src/unit_tests/rules/reduction_path_parity.rs
+++ b/src/unit_tests/rules/reduction_path_parity.rs
@@ -51,8 +51,7 @@ fn test_jl_parity_maxcut_to_spinglass_path() {
         (6, 9),
         (7, 9),
     ];
-    let source =
-        MaxCut::<SimpleGraph, i32>::unweighted(SimpleGraph::new(10, petersen_edges));
+    let source = MaxCut::<SimpleGraph, i32>::unweighted(SimpleGraph::new(10, petersen_edges));
     let reduction = path.reduce(&source);
     let target = reduction.target_problem();
 
@@ -107,8 +106,7 @@ fn test_jl_parity_maxcut_to_qubo_path() {
         (6, 9),
         (7, 9),
     ];
-    let source =
-        MaxCut::<SimpleGraph, i32>::unweighted(SimpleGraph::new(10, petersen_edges));
+    let source = MaxCut::<SimpleGraph, i32>::unweighted(SimpleGraph::new(10, petersen_edges));
     let reduction = path.reduce(&source);
 
     let solver = BruteForce::new();

--- a/src/unit_tests/rules/registry.rs
+++ b/src/unit_tests/rules/registry.rs
@@ -32,6 +32,8 @@ fn test_reduction_entry_overhead() {
         target_variant_fn: || vec![("graph", "SimpleGraph"), ("weight", "One")],
         overhead_fn: || ReductionOverhead::new(vec![("n", poly!(2 * n))]),
         module_path: "test::module",
+        source_size_names_fn: || &["n"],
+        target_size_names_fn: || &["n"],
         reduce_fn: dummy_reduce_fn,
     };
 
@@ -50,6 +52,8 @@ fn test_reduction_entry_debug() {
         target_variant_fn: || vec![("graph", "SimpleGraph"), ("weight", "One")],
         overhead_fn: || ReductionOverhead::default(),
         module_path: "test::module",
+        source_size_names_fn: || &[],
+        target_size_names_fn: || &[],
         reduce_fn: dummy_reduce_fn,
     };
 
@@ -67,6 +71,8 @@ fn test_is_base_reduction_unweighted() {
         target_variant_fn: || vec![("graph", "SimpleGraph"), ("weight", "One")],
         overhead_fn: || ReductionOverhead::default(),
         module_path: "test::module",
+        source_size_names_fn: || &[],
+        target_size_names_fn: || &[],
         reduce_fn: dummy_reduce_fn,
     };
     assert!(entry.is_base_reduction());
@@ -81,6 +87,8 @@ fn test_is_base_reduction_source_weighted() {
         target_variant_fn: || vec![("graph", "SimpleGraph"), ("weight", "One")],
         overhead_fn: || ReductionOverhead::default(),
         module_path: "test::module",
+        source_size_names_fn: || &[],
+        target_size_names_fn: || &[],
         reduce_fn: dummy_reduce_fn,
     };
     assert!(!entry.is_base_reduction());
@@ -95,6 +103,8 @@ fn test_is_base_reduction_target_weighted() {
         target_variant_fn: || vec![("graph", "SimpleGraph"), ("weight", "f64")],
         overhead_fn: || ReductionOverhead::default(),
         module_path: "test::module",
+        source_size_names_fn: || &[],
+        target_size_names_fn: || &[],
         reduce_fn: dummy_reduce_fn,
     };
     assert!(!entry.is_base_reduction());
@@ -109,6 +119,8 @@ fn test_is_base_reduction_both_weighted() {
         target_variant_fn: || vec![("graph", "SimpleGraph"), ("weight", "f64")],
         overhead_fn: || ReductionOverhead::default(),
         module_path: "test::module",
+        source_size_names_fn: || &[],
+        target_size_names_fn: || &[],
         reduce_fn: dummy_reduce_fn,
     };
     assert!(!entry.is_base_reduction());
@@ -124,6 +136,8 @@ fn test_is_base_reduction_no_weight_key() {
         target_variant_fn: || vec![("graph", "SimpleGraph")],
         overhead_fn: || ReductionOverhead::default(),
         module_path: "test::module",
+        source_size_names_fn: || &[],
+        target_size_names_fn: || &[],
         reduce_fn: dummy_reduce_fn,
     };
     assert!(entry.is_base_reduction());

--- a/src/unit_tests/rules/sat_circuitsat.rs
+++ b/src/unit_tests/rules/sat_circuitsat.rs
@@ -27,8 +27,7 @@ fn test_sat_to_circuitsat_closed_loop() {
         .iter()
         .map(|t| result.extract_solution(t))
         .collect();
-    let sat_solutions: HashSet<Vec<usize>> =
-        solver.find_all_satisfying(&sat).into_iter().collect();
+    let sat_solutions: HashSet<Vec<usize>> = solver.find_all_satisfying(&sat).into_iter().collect();
 
     // Every extracted solution must satisfy the original SAT
     for sol in &extracted {
@@ -41,10 +40,7 @@ fn test_sat_to_circuitsat_closed_loop() {
 #[test]
 fn test_sat_to_circuitsat_unsatisfiable() {
     // Unsatisfiable: (x1) & (!x1)
-    let sat = Satisfiability::new(
-        1,
-        vec![CNFClause::new(vec![1]), CNFClause::new(vec![-1])],
-    );
+    let sat = Satisfiability::new(1, vec![CNFClause::new(vec![1]), CNFClause::new(vec![-1])]);
     let result = ReduceTo::<CircuitSAT>::reduce_to(&sat);
     let solver = BruteForce::new();
     let best_target = solver.find_all_satisfying(result.target_problem());
@@ -66,8 +62,7 @@ fn test_sat_to_circuitsat_single_clause() {
         .iter()
         .map(|t| result.extract_solution(t))
         .collect();
-    let sat_solutions: HashSet<Vec<usize>> =
-        solver.find_all_satisfying(&sat).into_iter().collect();
+    let sat_solutions: HashSet<Vec<usize>> = solver.find_all_satisfying(&sat).into_iter().collect();
 
     assert_eq!(extracted, sat_solutions);
 }
@@ -75,10 +70,7 @@ fn test_sat_to_circuitsat_single_clause() {
 #[test]
 fn test_sat_to_circuitsat_single_literal_clause() {
     // Single literal clause: (x1) & (x2)
-    let sat = Satisfiability::new(
-        2,
-        vec![CNFClause::new(vec![1]), CNFClause::new(vec![2])],
-    );
+    let sat = Satisfiability::new(2, vec![CNFClause::new(vec![1]), CNFClause::new(vec![2])]);
     let result = ReduceTo::<CircuitSAT>::reduce_to(&sat);
     let solver = BruteForce::new();
 
@@ -87,8 +79,7 @@ fn test_sat_to_circuitsat_single_literal_clause() {
         .iter()
         .map(|t| result.extract_solution(t))
         .collect();
-    let sat_solutions: HashSet<Vec<usize>> =
-        solver.find_all_satisfying(&sat).into_iter().collect();
+    let sat_solutions: HashSet<Vec<usize>> = solver.find_all_satisfying(&sat).into_iter().collect();
 
     // Only solution should be x1=1, x2=1
     assert_eq!(extracted, sat_solutions);

--- a/src/unit_tests/rules/traits.rs
+++ b/src/unit_tests/rules/traits.rs
@@ -23,6 +23,9 @@ impl Problem for SourceProblem {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "i32")]
     }
+    fn problem_size(&self) -> crate::types::ProblemSize {
+        crate::types::ProblemSize::new(vec![("num_vars", 2)])
+    }
 }
 
 impl Problem for TargetProblem {
@@ -36,6 +39,9 @@ impl Problem for TargetProblem {
     }
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "i32")]
+    }
+    fn problem_size(&self) -> crate::types::ProblemSize {
+        crate::types::ProblemSize::new(vec![("num_vars", 2)])
     }
 }
 

--- a/src/unit_tests/rules/traits.rs
+++ b/src/unit_tests/rules/traits.rs
@@ -23,8 +23,11 @@ impl Problem for SourceProblem {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "i32")]
     }
-    fn problem_size(&self) -> crate::types::ProblemSize {
-        crate::types::ProblemSize::new(vec![("num_vars", 2)])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vars"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![2]
     }
 }
 
@@ -40,8 +43,11 @@ impl Problem for TargetProblem {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "i32")]
     }
-    fn problem_size(&self) -> crate::types::ProblemSize {
-        crate::types::ProblemSize::new(vec![("num_vars", 2)])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vars"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![2]
     }
 }
 

--- a/src/unit_tests/rules/travelingsalesman_ilp.rs
+++ b/src/unit_tests/rules/travelingsalesman_ilp.rs
@@ -14,8 +14,10 @@ fn k4_tsp() -> TravelingSalesman<SimpleGraph, i32> {
 #[test]
 fn test_reduction_creates_valid_ilp_c4() {
     // C4 cycle: 4 vertices, 4 edges. Unique Hamiltonian cycle (the cycle itself).
-    let problem =
-        TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3), (3, 0)]));
+    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        4,
+        vec![(0, 1), (1, 2), (2, 3), (3, 0)],
+    ));
     let reduction: ReductionTSPToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -32,8 +34,10 @@ fn test_reduction_creates_valid_ilp_c4() {
 #[test]
 fn test_reduction_c4_closed_loop() {
     // C4 cycle with unit weights: optimal tour cost = 4
-    let problem =
-        TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3), (3, 0)]));
+    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        4,
+        vec![(0, 1), (1, 2), (2, 3), (3, 0)],
+    ));
     let reduction: ReductionTSPToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 
@@ -75,9 +79,10 @@ fn test_reduction_k4_weighted_closed_loop() {
 #[test]
 fn test_reduction_c5_unweighted_closed_loop() {
     // C5 cycle with unit weights
-    let problem = TravelingSalesman::<_, i32>::unit_weights(
-        SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)]),
-    );
+    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        5,
+        vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)],
+    ));
 
     let reduction: ReductionTSPToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
@@ -93,8 +98,10 @@ fn test_reduction_c5_unweighted_closed_loop() {
 #[test]
 fn test_no_hamiltonian_cycle_infeasible() {
     // Path graph 0-1-2-3: no Hamiltonian cycle exists
-    let problem =
-        TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]));
+    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        4,
+        vec![(0, 1), (1, 2), (2, 3)],
+    ));
 
     let reduction: ReductionTSPToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
@@ -110,8 +117,10 @@ fn test_no_hamiltonian_cycle_infeasible() {
 #[test]
 fn test_solution_extraction_structure() {
     // C4 cycle: verify extraction produces correct edge selection format
-    let problem =
-        TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3), (3, 0)]));
+    let problem = TravelingSalesman::<_, i32>::unit_weights(SimpleGraph::new(
+        4,
+        vec![(0, 1), (1, 2), (2, 3), (3, 0)],
+    ));
     let reduction: ReductionTSPToILP = ReduceTo::<ILP>::reduce_to(&problem);
     let ilp = reduction.target_problem();
 

--- a/src/unit_tests/solvers/brute_force.rs
+++ b/src/unit_tests/solvers/brute_force.rs
@@ -27,8 +27,11 @@ impl Problem for MaxSumOpt {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "i32")]
     }
-    fn problem_size(&self) -> crate::types::ProblemSize {
-        crate::types::ProblemSize::new(vec![("num_vars", self.weights.len())])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vars"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.weights.len()]
     }
 }
 
@@ -63,8 +66,11 @@ impl Problem for MinSumOpt {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "i32")]
     }
-    fn problem_size(&self) -> crate::types::ProblemSize {
-        crate::types::ProblemSize::new(vec![("num_vars", self.weights.len())])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vars"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.weights.len()]
     }
 }
 
@@ -94,8 +100,11 @@ impl Problem for SatProblem {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "bool")]
     }
-    fn problem_size(&self) -> crate::types::ProblemSize {
-        crate::types::ProblemSize::new(vec![("num_vars", self.num_vars)])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vars"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.num_vars]
     }
 }
 

--- a/src/unit_tests/solvers/brute_force.rs
+++ b/src/unit_tests/solvers/brute_force.rs
@@ -255,7 +255,10 @@ fn test_solver_with_real_mis() {
     use crate::traits::Problem;
 
     // Triangle graph: MIS = 1
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+    let problem = MaximumIndependentSet::new(
+        SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+        vec![1i32; 3],
+    );
     let solver = BruteForce::new();
 
     let best = solver.find_all_best(&problem);

--- a/src/unit_tests/solvers/brute_force.rs
+++ b/src/unit_tests/solvers/brute_force.rs
@@ -27,6 +27,9 @@ impl Problem for MaxSumOpt {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "i32")]
     }
+    fn problem_size(&self) -> crate::types::ProblemSize {
+        crate::types::ProblemSize::new(vec![("num_vars", self.weights.len())])
+    }
 }
 
 impl OptimizationProblem for MaxSumOpt {
@@ -60,6 +63,9 @@ impl Problem for MinSumOpt {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "i32")]
     }
+    fn problem_size(&self) -> crate::types::ProblemSize {
+        crate::types::ProblemSize::new(vec![("num_vars", self.weights.len())])
+    }
 }
 
 impl OptimizationProblem for MinSumOpt {
@@ -87,6 +93,9 @@ impl Problem for SatProblem {
     }
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "bool")]
+    }
+    fn problem_size(&self) -> crate::types::ProblemSize {
+        crate::types::ProblemSize::new(vec![("num_vars", self.num_vars)])
     }
 }
 

--- a/src/unit_tests/testing/macros.rs
+++ b/src/unit_tests/testing/macros.rs
@@ -7,7 +7,8 @@ use crate::types::SolutionSize;
 fn test_quick_problem_test_macro() {
     // Test a valid solution
     {
-        let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+        let problem =
+            MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
         let solution = vec![1, 0, 1];
         let result = problem.evaluate(&solution);
         assert_eq!(result, SolutionSize::Valid(2));
@@ -15,7 +16,8 @@ fn test_quick_problem_test_macro() {
 
     // Test an invalid solution (adjacent vertices selected) -> returns Invalid
     {
-        let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
+        let problem =
+            MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1i32; 3]);
         let solution = vec![1, 1, 0];
         let result = problem.evaluate(&solution);
         assert_eq!(result, SolutionSize::Invalid);
@@ -31,7 +33,8 @@ fn test_is_vc_complement() {
         (3usize, vec![(0, 1), (1, 2)]),
         (4usize, vec![(0, 1), (1, 2), (2, 3), (0, 3)]),
     ] {
-        let problem_a = MaximumIndependentSet::new(SimpleGraph::new(n, edges.clone()), vec![1i32; n]);
+        let problem_a =
+            MaximumIndependentSet::new(SimpleGraph::new(n, edges.clone()), vec![1i32; n]);
         let problem_b = MinimumVertexCover::new(SimpleGraph::new(n, edges), vec![1i32; n]);
 
         let solver = BruteForce::new();

--- a/src/unit_tests/trait_consistency.rs
+++ b/src/unit_tests/trait_consistency.rs
@@ -3,7 +3,7 @@ use crate::models::optimization::*;
 use crate::models::satisfiability::*;
 use crate::models::set::*;
 use crate::models::specialized::*;
-use crate::topology::SimpleGraph;
+use crate::topology::{BipartiteGraph, SimpleGraph};
 use crate::traits::Problem;
 use crate::variant::K3;
 
@@ -72,7 +72,7 @@ fn test_all_problems_implement_trait_correctly() {
     );
     check_problem_trait(&PaintShop::new(vec!["a", "a"]), "PaintShop");
     check_problem_trait(&BMF::new(vec![vec![true]], 1), "BMF");
-    check_problem_trait(&BicliqueCover::new(2, 2, vec![(0, 2)], 1), "BicliqueCover");
+    check_problem_trait(&BicliqueCover::new(BipartiteGraph::new(2, 2, vec![(0, 0)]), 1), "BicliqueCover");
     check_problem_trait(&Factoring::new(6, 2, 2), "Factoring");
 
     let circuit = Circuit::new(vec![Assignment::new(
@@ -118,7 +118,7 @@ fn test_direction() {
     );
     assert_eq!(Factoring::new(6, 2, 2).direction(), Direction::Minimize);
     assert_eq!(
-        BicliqueCover::new(2, 2, vec![(0, 2)], 1).direction(),
+        BicliqueCover::new(BipartiteGraph::new(2, 2, vec![(0, 0)]), 1).direction(),
         Direction::Minimize
     );
 

--- a/src/unit_tests/traits.rs
+++ b/src/unit_tests/traits.rs
@@ -21,6 +21,9 @@ impl Problem for TestSatProblem {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "bool")]
     }
+    fn problem_size(&self) -> crate::types::ProblemSize {
+        crate::types::ProblemSize::new(vec![("num_vars", self.num_vars)])
+    }
 }
 
 #[test]
@@ -79,6 +82,9 @@ impl Problem for TestMaxProblem {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "i32")]
     }
+    fn problem_size(&self) -> crate::types::ProblemSize {
+        crate::types::ProblemSize::new(vec![("num_vars", self.weights.len())])
+    }
 }
 
 impl OptimizationProblem for TestMaxProblem {
@@ -110,6 +116,9 @@ impl Problem for TestMinProblem {
     }
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "i32")]
+    }
+    fn problem_size(&self) -> crate::types::ProblemSize {
+        crate::types::ProblemSize::new(vec![("num_vars", self.costs.len())])
     }
 }
 
@@ -161,6 +170,9 @@ impl Problem for MultiDimProblem {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "i32")]
     }
+    fn problem_size(&self) -> crate::types::ProblemSize {
+        crate::types::ProblemSize::new(vec![("num_dims", self.dims.len())])
+    }
 }
 
 #[test]
@@ -209,6 +221,9 @@ impl Problem for FloatProblem {
     }
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "f64")]
+    }
+    fn problem_size(&self) -> crate::types::ProblemSize {
+        crate::types::ProblemSize::new(vec![("num_vars", self.weights.len())])
     }
 }
 

--- a/src/unit_tests/traits.rs
+++ b/src/unit_tests/traits.rs
@@ -21,8 +21,11 @@ impl Problem for TestSatProblem {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "bool")]
     }
-    fn problem_size(&self) -> crate::types::ProblemSize {
-        crate::types::ProblemSize::new(vec![("num_vars", self.num_vars)])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vars"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.num_vars]
     }
 }
 
@@ -82,8 +85,11 @@ impl Problem for TestMaxProblem {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "i32")]
     }
-    fn problem_size(&self) -> crate::types::ProblemSize {
-        crate::types::ProblemSize::new(vec![("num_vars", self.weights.len())])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vars"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.weights.len()]
     }
 }
 
@@ -117,8 +123,11 @@ impl Problem for TestMinProblem {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "i32")]
     }
-    fn problem_size(&self) -> crate::types::ProblemSize {
-        crate::types::ProblemSize::new(vec![("num_vars", self.costs.len())])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vars"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.costs.len()]
     }
 }
 
@@ -170,8 +179,11 @@ impl Problem for MultiDimProblem {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "i32")]
     }
-    fn problem_size(&self) -> crate::types::ProblemSize {
-        crate::types::ProblemSize::new(vec![("num_dims", self.dims.len())])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_dims"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.dims.len()]
     }
 }
 
@@ -222,8 +234,11 @@ impl Problem for FloatProblem {
     fn variant() -> Vec<(&'static str, &'static str)> {
         vec![("graph", "SimpleGraph"), ("weight", "f64")]
     }
-    fn problem_size(&self) -> crate::types::ProblemSize {
-        crate::types::ProblemSize::new(vec![("num_vars", self.weights.len())])
+    fn problem_size_names() -> &'static [&'static str] {
+        &["num_vars"]
+    }
+    fn problem_size_values(&self) -> Vec<usize> {
+        vec![self.weights.len()]
     }
 }
 

--- a/src/unit_tests/unitdiskmapping_algorithms/common.rs
+++ b/src/unit_tests/unitdiskmapping_algorithms/common.rs
@@ -20,7 +20,10 @@ pub fn is_independent_set(edges: &[(usize, usize)], config: &[usize]) -> bool {
 /// Solve maximum independent set using ILP.
 /// Returns the size of the MIS.
 pub fn solve_mis(num_vertices: usize, edges: &[(usize, usize)]) -> usize {
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(num_vertices, edges.to_vec()), vec![1i32; num_vertices]);
+    let problem = MaximumIndependentSet::new(
+        SimpleGraph::new(num_vertices, edges.to_vec()),
+        vec![1i32; num_vertices],
+    );
     let reduction = <MaximumIndependentSet<SimpleGraph, i32> as ReduceTo<ILP>>::reduce_to(&problem);
     let solver = ILPSolver::new();
     if let Some(solution) = solver.solve(reduction.target_problem()) {
@@ -32,7 +35,10 @@ pub fn solve_mis(num_vertices: usize, edges: &[(usize, usize)]) -> usize {
 
 /// Solve MIS and return the binary configuration.
 pub fn solve_mis_config(num_vertices: usize, edges: &[(usize, usize)]) -> Vec<usize> {
-    let problem = MaximumIndependentSet::new(SimpleGraph::new(num_vertices, edges.to_vec()), vec![1i32; num_vertices]);
+    let problem = MaximumIndependentSet::new(
+        SimpleGraph::new(num_vertices, edges.to_vec()),
+        vec![1i32; num_vertices],
+    );
     let reduction = <MaximumIndependentSet<SimpleGraph, i32> as ReduceTo<ILP>>::reduce_to(&problem);
     let solver = ILPSolver::new();
     if let Some(solution) = solver.solve(reduction.target_problem()) {

--- a/tests/suites/integration.rs
+++ b/tests/suites/integration.rs
@@ -17,8 +17,10 @@ mod all_problems_solvable {
 
     #[test]
     fn test_independent_set_solvable() {
-        let problem =
-            MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+        let problem = MaximumIndependentSet::new(
+            SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+            vec![1i32; 4],
+        );
         let solver = BruteForce::new();
         let solutions = solver.find_all_best(&problem);
         assert!(!solutions.is_empty());
@@ -29,7 +31,10 @@ mod all_problems_solvable {
 
     #[test]
     fn test_vertex_covering_solvable() {
-        let problem = MinimumVertexCover::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+        let problem = MinimumVertexCover::new(
+            SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+            vec![1i32; 4],
+        );
         let solver = BruteForce::new();
         let solutions = solver.find_all_best(&problem);
         assert!(!solutions.is_empty());
@@ -40,7 +45,10 @@ mod all_problems_solvable {
 
     #[test]
     fn test_max_cut_solvable() {
-        let problem = MaxCut::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1, 2, 1]);
+        let problem = MaxCut::new(
+            SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+            vec![1, 2, 1],
+        );
         let solver = BruteForce::new();
         let solutions = solver.find_all_best(&problem);
         assert!(!solutions.is_empty());
@@ -60,8 +68,10 @@ mod all_problems_solvable {
 
     #[test]
     fn test_dominating_set_solvable() {
-        let problem =
-            MinimumDominatingSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+        let problem = MinimumDominatingSet::new(
+            SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+            vec![1i32; 4],
+        );
         let solver = BruteForce::new();
         let solutions = solver.find_all_best(&problem);
         assert!(!solutions.is_empty());
@@ -72,7 +82,10 @@ mod all_problems_solvable {
 
     #[test]
     fn test_maximal_is_solvable() {
-        let problem = MaximalIS::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+        let problem = MaximalIS::new(
+            SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+            vec![1i32; 4],
+        );
         let solver = BruteForce::new();
         let solutions = solver.find_all_best(&problem);
         assert!(!solutions.is_empty());
@@ -83,8 +96,10 @@ mod all_problems_solvable {
 
     #[test]
     fn test_matching_solvable() {
-        let problem =
-            MaximumMatching::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1, 2, 1]);
+        let problem = MaximumMatching::new(
+            SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+            vec![1, 2, 1],
+        );
         let solver = BruteForce::new();
         let solutions = solver.find_all_best(&problem);
         assert!(!solutions.is_empty());
@@ -233,7 +248,8 @@ mod problem_relationships {
         let edges = vec![(0, 1), (1, 2), (2, 3), (0, 3)];
         let n = 4;
 
-        let is_problem = MaximumIndependentSet::new(SimpleGraph::new(n, edges.clone()), vec![1i32; n]);
+        let is_problem =
+            MaximumIndependentSet::new(SimpleGraph::new(n, edges.clone()), vec![1i32; n]);
         let vc_problem = MinimumVertexCover::new(SimpleGraph::new(n, edges), vec![1i32; n]);
 
         let solver = BruteForce::new();
@@ -401,10 +417,7 @@ mod weighted_problems {
 
     #[test]
     fn test_weighted_independent_set() {
-        let problem = MaximumIndependentSet::new(
-            SimpleGraph::new(3, vec![(0, 1)]),
-            vec![10, 1, 1],
-        );
+        let problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![10, 1, 1]);
 
         let solver = BruteForce::new();
         let solutions = solver.find_all_best(&problem);
@@ -421,10 +434,8 @@ mod weighted_problems {
 
     #[test]
     fn test_weighted_vertex_cover() {
-        let problem = MinimumVertexCover::new(
-            SimpleGraph::new(3, vec![(0, 1), (1, 2)]),
-            vec![1, 10, 1],
-        );
+        let problem =
+            MinimumVertexCover::new(SimpleGraph::new(3, vec![(0, 1), (1, 2)]), vec![1, 10, 1]);
 
         let solver = BruteForce::new();
         let solutions = solver.find_all_best(&problem);

--- a/tests/suites/integration.rs
+++ b/tests/suites/integration.rs
@@ -9,7 +9,7 @@ use problemreductions::models::satisfiability::*;
 use problemreductions::models::set::*;
 use problemreductions::models::specialized::*;
 use problemreductions::prelude::*;
-use problemreductions::topology::SimpleGraph;
+use problemreductions::topology::{BipartiteGraph, SimpleGraph};
 
 /// Test that all problem types can be instantiated and solved.
 mod all_problems_solvable {
@@ -215,7 +215,7 @@ mod all_problems_solvable {
     #[test]
     fn test_biclique_cover_solvable() {
         // Left vertices: 0, 1; Right vertices: 2, 3
-        let problem = BicliqueCover::new(2, 2, vec![(0, 2), (0, 3), (1, 2), (1, 3)], 1);
+        let problem = BicliqueCover::new(BipartiteGraph::new(2, 2, vec![(0, 0), (0, 1), (1, 0), (1, 1)]), 1);
         let solver = BruteForce::new();
         let solutions = solver.find_all_best(&problem);
         assert!(!solutions.is_empty());

--- a/tests/suites/reductions.rs
+++ b/tests/suites/reductions.rs
@@ -13,8 +13,10 @@ mod is_vc_reductions {
     #[test]
     fn test_is_to_vc_basic() {
         // Triangle graph
-        let is_problem =
-            MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+        let is_problem = MaximumIndependentSet::new(
+            SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+            vec![1i32; 3],
+        );
 
         // Reduce IS to VC
         let result = ReduceTo::<MinimumVertexCover<SimpleGraph, i32>>::reduce_to(&is_problem);
@@ -38,8 +40,10 @@ mod is_vc_reductions {
     #[test]
     fn test_vc_to_is_basic() {
         // Path graph
-        let vc_problem =
-            MinimumVertexCover::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+        let vc_problem = MinimumVertexCover::new(
+            SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+            vec![1i32; 4],
+        );
 
         // Reduce VC to IS
         let result = ReduceTo::<MaximumIndependentSet<SimpleGraph, i32>>::reduce_to(&vc_problem);
@@ -62,8 +66,10 @@ mod is_vc_reductions {
 
     #[test]
     fn test_is_vc_roundtrip() {
-        let original =
-            MaximumIndependentSet::new(SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]), vec![1i32; 5]);
+        let original = MaximumIndependentSet::new(
+            SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            vec![1i32; 5],
+        );
 
         // IS -> VC
         let to_vc = ReduceTo::<MinimumVertexCover<SimpleGraph, i32>>::reduce_to(&original);
@@ -94,7 +100,8 @@ mod is_vc_reductions {
 
     #[test]
     fn test_is_vc_weighted() {
-        let is_problem = MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![10, 1, 5]);
+        let is_problem =
+            MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1)]), vec![10, 1, 5]);
 
         let result = ReduceTo::<MinimumVertexCover<SimpleGraph, i32>>::reduce_to(&is_problem);
         let vc_problem = result.target_problem();
@@ -109,7 +116,8 @@ mod is_vc_reductions {
         let edges = vec![(0, 1), (1, 2), (2, 3), (0, 3)];
         let n = 4;
 
-        let is_problem = MaximumIndependentSet::new(SimpleGraph::new(n, edges.clone()), vec![1i32; n]);
+        let is_problem =
+            MaximumIndependentSet::new(SimpleGraph::new(n, edges.clone()), vec![1i32; n]);
         let vc_problem = MinimumVertexCover::new(SimpleGraph::new(n, edges), vec![1i32; n]);
 
         let solver = BruteForce::new();
@@ -132,8 +140,10 @@ mod is_sp_reductions {
     #[test]
     fn test_is_to_sp_basic() {
         // Triangle graph - each vertex's incident edges become a set
-        let is_problem =
-            MaximumIndependentSet::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![1i32; 3]);
+        let is_problem = MaximumIndependentSet::new(
+            SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+            vec![1i32; 3],
+        );
 
         let result = ReduceTo::<MaximumSetPacking<i32>>::reduce_to(&is_problem);
         let sp_problem = result.target_problem();
@@ -177,8 +187,10 @@ mod is_sp_reductions {
 
     #[test]
     fn test_is_sp_roundtrip() {
-        let original =
-            MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+        let original = MaximumIndependentSet::new(
+            SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+            vec![1i32; 4],
+        );
 
         // IS -> SP
         let to_sp = ReduceTo::<MaximumSetPacking<i32>>::reduce_to(&original);
@@ -310,7 +322,10 @@ mod sg_maxcut_reductions {
 
     #[test]
     fn test_maxcut_to_sg_basic() {
-        let maxcut = MaxCut::new(SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]), vec![2, 1, 3]);
+        let maxcut = MaxCut::new(
+            SimpleGraph::new(3, vec![(0, 1), (1, 2), (0, 2)]),
+            vec![2, 1, 3],
+        );
 
         let result = ReduceTo::<SpinGlass<SimpleGraph, i32>>::reduce_to(&maxcut);
         let sg = result.target_problem();
@@ -485,10 +500,7 @@ mod qubo_reductions {
         let data: ISToQuboData = serde_json::from_str(&json).unwrap();
 
         let n = data.source.num_vertices;
-        let is = MaximumIndependentSet::new(
-            SimpleGraph::new(n, data.source.edges),
-            vec![1i32; n],
-        );
+        let is = MaximumIndependentSet::new(SimpleGraph::new(n, data.source.edges), vec![1i32; n]);
         let reduction = ReduceTo::<QUBO>::reduce_to(&is);
         let qubo = reduction.target_problem();
 
@@ -529,10 +541,7 @@ mod qubo_reductions {
         let data: VCToQuboData = serde_json::from_str(&json).unwrap();
 
         let n = data.source.num_vertices;
-        let vc = MinimumVertexCover::new(
-            SimpleGraph::new(n, data.source.edges),
-            vec![1i32; n],
-        );
+        let vc = MinimumVertexCover::new(SimpleGraph::new(n, data.source.edges), vec![1i32; n]);
         let reduction = ReduceTo::<QUBO>::reduce_to(&vc);
         let qubo = reduction.target_problem();
 
@@ -573,7 +582,10 @@ mod qubo_reductions {
 
         assert_eq!(data.source.num_colors, 3);
 
-        let kc = KColoring::<K3, _>::new(SimpleGraph::new(data.source.num_vertices, data.source.edges));
+        let kc = KColoring::<K3, _>::new(SimpleGraph::new(
+            data.source.num_vertices,
+            data.source.edges,
+        ));
         let reduction = ReduceTo::<QUBO>::reduce_to(&kc);
         let qubo = reduction.target_problem();
 
@@ -787,8 +799,10 @@ mod io_tests {
 
     #[test]
     fn test_serialize_reduce_deserialize() {
-        let original =
-            MaximumIndependentSet::new(SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]), vec![1i32; 4]);
+        let original = MaximumIndependentSet::new(
+            SimpleGraph::new(4, vec![(0, 1), (1, 2), (2, 3)]),
+            vec![1i32; 4],
+        );
 
         // Serialize
         let json = to_json(&original).unwrap();


### PR DESCRIPTION
## Summary
- Add required `problem_size()` method to `Problem` trait returning `ProblemSize` with named size components
- Implement `problem_size()` for all 21 problem types across graph, SAT, set, optimization, and specialized categories
- Add `variable_names()` to `Polynomial` and `input_variable_names()` to `ReductionOverhead` for overhead introspection
- Validate that overhead polynomial variable names match source `problem_size()` components in `find_cheapest_path` (catches naming mismatches at path-finding time)
- Add 21 unit tests (one per problem type) and an integration test for `find_cheapest_path` with real problem sizes

## Test plan
- [x] All 21 `test_problem_size_*` unit tests pass verifying correct component names and values
- [x] `test_find_cheapest_path_with_problem_size` integration test passes with real Petersen graph
- [x] All 1471+ existing tests continue to pass (updated 5 tests that used incorrect variable names)
- [x] `make clippy` passes with zero warnings
- [x] `make fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)