### PR TITLE
Fix #191: Address 5 skill workflow issues

### DIFF
--- a/.claude/skills/add-model/SKILL.md
+++ b/.claude/skills/add-model/SKILL.md
@@ -122,7 +122,7 @@ Update the CLI dispatch table so `pred` can load, solve, and serialize the new p
 
 2. **`problemreductions-cli/src/problem_name.rs`:**
    - Add a lowercase alias mapping in `resolve_alias()` (e.g., `"newproblem" => "NewProblem".to_string()`)
-   - Optionally add short aliases to `ALIASES` array (e.g., `("NP", "NewProblem")`)
+   - Only add short aliases to the `ALIASES` array if the abbreviation is **well-established in the literature** (e.g., MIS, MVC, SAT, TSP, CVP are standard; "KS" for Knapsack or "BP" for BinPacking are NOT — do not invent new abbreviations)
 
 ## Step 4.5: Add CLI creation support
 
@@ -183,5 +183,6 @@ If running standalone (not inside `make run-plan`), invoke [review-implementatio
 | Forgetting `declare_variants!` | Required for variant complexity metadata used by the paper's auto-generated table |
 | Forgetting CLI dispatch | Must add match arms in `dispatch.rs` (`load_problem` + `serialize_any_problem`) |
 | Forgetting CLI alias | Must add lowercase entry in `problem_name.rs` `resolve_alias()` |
+| Inventing short aliases | Only use well-established literature abbreviations (MIS, SAT, TSP); do NOT invent new ones |
 | Forgetting CLI create | Must add creation handler in `commands/create.rs` and flags in `cli.rs` |
 | Schema lists derived fields | Schema should list constructor params, not internal fields (e.g., `matrix, k` not `matrix, m, n, k`) |

--- a/.claude/skills/check-issue/SKILL.md
+++ b/.claude/skills/check-issue/SKILL.md
@@ -423,10 +423,32 @@ If an MCP tool is not available, skip to the next in the chain. All checks shoul
 
 ---
 
+## Step 3: Offer to Fix (optional)
+
+After posting the report, if there are **fixable failures** (not just warnings), ask the user:
+
+> "Would you like me to help fix the issues found? I can update the issue body to address: [list fixable items]"
+
+**Auto-fixable items** (if the user agrees):
+- Missing or placeholder sections → fill with templates from the issue template
+- Incorrect DOI format → reformat to standard `https://doi.org/...` form
+- Inconsistent notation → standardize symbols across sections
+- Missing symbol definitions → add definitions based on context
+
+**NOT auto-fixable** (require the contributor's input):
+- Missing reduction algorithm or proof details
+- Incorrect mathematical claims
+- Missing references (need the contributor to provide them)
+
+If the user agrees, edit the issue body with `gh issue edit <NUMBER> --body "..."` and re-run the checks to verify the fixes.
+
+---
+
 ## Common Mistakes
 
 - **Don't fail on warnings.** Only add labels for definitive failures. Ambiguous cases get warnings.
 - **Don't close issues.** This skill labels and comments only.
 - **Don't hallucinate paper content.** If you can't find a paper, say "not found" — don't guess what it might contain.
+- **Don't hallucinate issue references.** Do NOT reference other GitHub issues unless you have fetched them with `gh issue view` and verified their content. Do NOT reference file paths unless you have verified they exist.
 - **Match problem names carefully.** Issues may use aliases (MIS, MVC, SAT) that need resolution via `pred show`.
 - **Check the right template.** `[Rule]` and `[Model]` issues have different sections — don't check for "Reduction Algorithm" on a Model issue.

--- a/.claude/skills/issue-to-pr/SKILL.md
+++ b/.claude/skills/issue-to-pr/SKILL.md
@@ -54,6 +54,17 @@ LABELS=$(gh issue view <number> --json labels --jq '[.labels[].name] | join(",")
 - If `Good` is NOT in the labels → **STOP**: "Issue #N has not passed check-issue. Please run `/check-issue <N>` first."
 - If `Good` is present → continue to step 4.
 
+### 3.5. Check for Related Open PRs
+
+When creating a `[Rule]` PR, check if there's already an open `[Model]` PR for the source or target problem:
+
+```bash
+gh pr list --state open --search "[Model]" --json title,number,headRefName
+```
+
+- If an open Model PR exists for the source/target problem, the Rule PR should **base its branch on that Model branch** (not `main`), to avoid duplicating CLI registration, export regeneration, etc.
+- If both a `[Model]` and `[Rule]` issue exist for the same problem, prefer implementing them in the **same PR** to avoid redundant work. Base the branch on `main`, implement the model first, then the rule.
+
 ### 4. Research References
 
 Use `WebSearch` and `WebFetch` to look up the reference URL provided in the issue. This helps:
@@ -157,7 +168,16 @@ git add -A
 git commit -m "Implement #<number>: <title>"
 ```
 
-#### 7c. Push, Post Summary, and Request Copilot Review
+#### 7c. Clean Up Plan File
+
+Delete the plan file from the branch — it served its purpose during implementation and should not be merged into main:
+
+```bash
+git rm docs/plans/<plan-file>.md
+git commit -m "chore: remove plan file after implementation"
+```
+
+#### 7d. Push, Post Summary, and Request Copilot Review
 
 Post an implementation summary comment on the PR **before** pushing. This comment should:
 - Summarize what was implemented (files added/changed)
@@ -183,7 +203,7 @@ git push
 make copilot-review
 ```
 
-#### 7d. Fix Loop (max 3 retries)
+#### 7e. Fix Loop (max 3 retries)
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
@@ -231,7 +251,7 @@ For each retry:
 
 **After 3 failed retries:** leave PR open, report to user.
 
-#### 7e. Done
+#### 7f. Done
 
 Report final status:
 - PR URL
@@ -283,3 +303,5 @@ PR #45: CI green, ready for merge.
 | Not verifying facts from issue | Use WebSearch/WebFetch to cross-check claims |
 | Branch already exists on retry | Check with `git rev-parse --verify` before `git checkout -b` |
 | Dirty working tree | Verify `git status --porcelain` is empty before branching |
+| Redundant Model+Rule PRs | Check for related open PRs (Step 3.5); combine or base on existing branch |
+| Plan files left in PR | Delete plan files before final push (Step 7c) |


### PR DESCRIPTION
## Summary

Targeted fixes for the 5 skill problems identified in #191, plus 5 additional findings documented in a comment on the issue.

### Changes

**check-issue/SKILL.md:**
- Added **Step 3: Offer to Fix** — after posting the report, the skill now asks the user whether to auto-fix correctable issues (missing sections, DOI formatting, notation inconsistencies)
- Added anti-hallucination guard to Common Mistakes: "Do NOT reference other GitHub issues unless fetched with `gh issue view`; do NOT reference file paths unless verified" (addresses problem #5 — hallucinated issue #16 on Steiner Tree #122)

**add-model/SKILL.md:**
- Restricted short alias guidance: only add to `ALIASES` array if the abbreviation is **well-established in the literature** (MIS, SAT, TSP); do not invent new ones like KS or BP (addresses problem #2)
- Added "Inventing short aliases" to Common Mistakes table

**issue-to-pr/SKILL.md:**
- Added **Step 3.5: Check for Related Open PRs** — before creating a Rule PR, check for existing Model PRs on the same problem to avoid redundant CLI registration and export work (addresses problem #4)
- Added **Step 7c: Clean Up Plan File** — delete `docs/plans/*.md` before final push so plan files don't get merged into main (addresses problem #3)
- Added two new Common Mistakes entries for redundant PRs and leftover plan files

### Additional findings (documented in [issue comment](https://github.com/CodingThrust/problem-reductions/issues/191#issuecomment-4025305939))

6. No alias quality convention documented anywhere
7. `check-issue` references.md is a static snapshot that can become stale
8. `issue-to-pr` "Good" label gate may block legitimate issues without documentation
9. Example indexing inconsistency between `add-model` and `issue-to-pr`
10. `add-model` Step 4.5 CLI creation support is fragile for non-standard problems

Fixes #191

## Test plan

- [ ] Verify skill markdown renders correctly
- [ ] Test `/check-issue` on a known issue to confirm Step 3 prompt appears
- [ ] Test `/issue-to-pr` to confirm plan file cleanup and related PR check work
- [ ] Test `/add-model` to confirm alias guidance is followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)