### PR TITLE
fix: check-issue delegates overhead comparison to check-rule-redundancy

### DIFF
--- a/.claude/skills/check-issue/SKILL.md
+++ b/.claude/skills/check-issue/SKILL.md
@@ -71,12 +71,10 @@ Applies when the title contains `[Rule]`.
 
 4. Decision (principle: new rule must reduce the reduction overhead):
    - **No path exists** → **Pass** (novel reduction)
-   - **Path exists** → compare overhead:
-     - Parse the proposed overhead from the issue's "Size Overhead" table
-     - Parse the overhead of the path.
-     - If proposed overhead is **strictly lower** on at least one dimension (and not higher on any) → **Pass** ("improves existing reduction")
-     - If overhead is **equal or higher** on all dimensions → **Fail**
-     - If overhead comparison is ambiguous (different dimensions, incomparable expressions) → **Warn** with explanation
+   - **Path exists** → run `/check-rule-redundancy <source> <target>` to perform a full overhead dominance analysis against all composite paths. Use its verdict:
+     - **Not Redundant** → **Pass** ("improves existing reduction — not dominated by any composite path")
+     - **Redundant** (dominated by a composite path) → **Fail** — include the dominating path from the redundancy report
+     - **Inconclusive** → **Warn** with the details from the redundancy report
 
 5. Check **Motivation** field: if empty, placeholder, or just "enables X" without explaining *why this path matters* → **Warn**
 


### PR DESCRIPTION
## Summary
- The check-issue skill's Rule Check 1 (Usefulness) now invokes `/check-rule-redundancy <source> <target>` instead of manually parsing and comparing overhead tables
- Maps the redundancy verdict directly: Not Redundant → Pass, Redundant → Fail, Inconclusive → Warn

## Test plan
- [ ] Run `/check-issue` on a `[Rule]` issue where a path already exists and verify it invokes `/check-rule-redundancy`
- [ ] Verify novel rules (no existing path) still pass without invoking the redundancy check

🤖 Generated with [Claude Code](https://claude.com/claude-code)