### PR TITLE
Fix #789: HC→StackerCrane connector cost prevents incorrect solution extraction

### DIFF
--- a/src/rules/hamiltoniancircuit_stackercrane.rs
+++ b/src/rules/hamiltoniancircuit_stackercrane.rs
@@ -4,11 +4,13 @@
 //! Each vertex v_i is split into v_i^in (= 2i) and v_i^out (= 2i+1). A mandatory
 //! directed arc (v_i^in → v_i^out) of length 1 is added for each vertex. For each
 //! undirected edge {v_i, v_j} in the source graph, two undirected connector edges
-//! {v_i^out, v_j^in} and {v_j^out, v_i^in} of length 0 are added.
+//! {v_i^out, v_j^in} and {v_j^out, v_i^in} of length 1 are added.
 //!
 //! The source graph has a Hamiltonian circuit iff the optimal Stacker Crane tour
-//! cost equals n (the number of vertices), since each arc contributes cost 1 and
-//! each zero-cost connector edge links consecutive arcs for free.
+//! cost equals 2n (n arcs of cost 1 plus n single-hop connectors of cost 1).
+//! Using connector length 1 (rather than 0) ensures that multi-hop connector
+//! paths cost strictly more than single-hop ones, so every optimal permutation
+//! corresponds to a valid Hamiltonian circuit.
 
 use crate::models::graph::HamiltonianCircuit;
 use crate::models::misc::StackerCrane;
@@ -59,15 +61,17 @@ impl ReduceTo<StackerCrane> for HamiltonianCircuit<SimpleGraph> {
         let arc_lengths: Vec<i32> = vec![1; n];
 
         // For each original edge {u, v}, add two undirected connector edges:
-        //   {u^out, v^in} = {2u+1, 2v}  with length 0
-        //   {v^out, u^in} = {2v+1, 2u}  with length 0
+        //   {u^out, v^in} = {2u+1, 2v}  with length 1
+        //   {v^out, u^in} = {2v+1, 2u}  with length 1
+        // Using length 1 (not 0) prevents multi-hop zero-cost shortcuts that
+        // would create optimal SC permutations not corresponding to valid HCs.
         let mut edges = Vec::new();
         let mut edge_lengths = Vec::new();
         for (u, v) in self.graph().edges() {
             edges.push((2 * u + 1, 2 * v));
-            edge_lengths.push(0);
+            edge_lengths.push(1);
             edges.push((2 * v + 1, 2 * u));
-            edge_lengths.push(0);
+            edge_lengths.push(1);
         }
 
         let target = StackerCrane::new(target_num_vertices, arcs, edges, arc_lengths, edge_lengths);

--- a/src/unit_tests/rules/hamiltoniancircuit_stackercrane.rs
+++ b/src/unit_tests/rules/hamiltoniancircuit_stackercrane.rs
@@ -41,15 +41,15 @@ fn test_hamiltoniancircuit_to_stackercrane_structure() {
     for &len in target.arc_lengths() {
         assert_eq!(len, 1);
     }
-    // All edges have length 0
+    // All connector edges have length 1
     for &len in target.edge_lengths() {
-        assert_eq!(len, 0);
+        assert_eq!(len, 1);
     }
 }
 
 #[test]
 fn test_hamiltoniancircuit_to_stackercrane_optimal_cost() {
-    // A 4-cycle has a Hamiltonian circuit; optimal StackerCrane cost = 4.
+    // A 4-cycle has a Hamiltonian circuit; optimal StackerCrane cost = 2n = 8.
     let source = cycle4_hc();
     let reduction = ReduceTo::<StackerCrane>::reduce_to(&source);
     let target = reduction.target_problem();
@@ -58,13 +58,13 @@ fn test_hamiltoniancircuit_to_stackercrane_optimal_cost() {
         .find_witness(target)
         .expect("target should have a solution");
     let cost = target.evaluate(&witness);
-    assert_eq!(cost, Min(Some(4)));
+    assert_eq!(cost, Min(Some(8)));
 }
 
 #[test]
 fn test_hamiltoniancircuit_to_stackercrane_non_hamiltonian() {
     // Star graph on 4 vertices: no Hamiltonian circuit.
-    // The optimal StackerCrane cost should exceed n = 4.
+    // The optimal StackerCrane cost should exceed 2n = 8.
     let source = HamiltonianCircuit::new(SimpleGraph::star(4));
     let reduction = ReduceTo::<StackerCrane>::reduce_to(&source);
     let target = reduction.target_problem();
@@ -74,8 +74,8 @@ fn test_hamiltoniancircuit_to_stackercrane_non_hamiltonian() {
         Some(w) => {
             let cost = target.evaluate(&w);
             assert!(
-                cost.0.unwrap() > 4,
-                "non-Hamiltonian graph should have cost > n"
+                cost.0.unwrap() > 8,
+                "non-Hamiltonian graph should have cost > 2n"
             );
         }
         None => {
@@ -97,5 +97,31 @@ fn test_hamiltoniancircuit_to_stackercrane_extract_solution() {
     assert!(
         source.evaluate(&extracted).0,
         "extracted solution should be a valid HC"
+    );
+}
+
+#[test]
+fn test_hamiltoniancircuit_to_stackercrane_prism_graph() {
+    // Regression test for #789: prism graph (6 vertices, 9 edges) has a
+    // Hamiltonian circuit, but with zero-cost connectors the ILP could find
+    // an optimal SC permutation that doesn't correspond to a valid HC.
+    let edges = vec![
+        (0, 1),
+        (1, 2),
+        (2, 0),
+        (3, 4),
+        (4, 5),
+        (5, 3),
+        (0, 3),
+        (1, 4),
+        (2, 5),
+    ];
+    let source = HamiltonianCircuit::new(SimpleGraph::new(6, edges));
+    let reduction = ReduceTo::<StackerCrane>::reduce_to(&source);
+
+    assert_satisfaction_round_trip_from_optimization_target(
+        &source,
+        &reduction,
+        "HamiltonianCircuit -> StackerCrane (prism graph)",
     );
 }


### PR DESCRIPTION
## Summary

Fixes #789: the reduction chain `HamiltonianCircuit → StackerCrane → ILP` returned `Or(false)` on the prism graph, which has a valid Hamiltonian circuit.

## Root Cause

The HC→StackerCrane reduction splits each vertex $v_i$ into $v_i^{in}$ (= $2i$) and $v_i^{out}$ (= $2i+1$), adding:
- A mandatory directed arc ($2i → 2i+1$) of length 1 per vertex
- Two undirected connector edges per original edge $\{u,v\}$: $\{2u+1, 2v\}$ and $\{2v+1, 2u\}$, originally with **length 0**

The zero-cost connectors form a rich network where **multi-hop paths are also zero-cost**. On the prism graph, vertices 5 and 6 have no direct connector (original edge $\{2,3\}$ doesn't exist), but a 5-hop zero-cost path exists:

```
5 →(0) 0 →(0) 7 →(0) 10 →(0) 9 →(0) 6
```

This means the ILP can find an optimal SC permutation `[1, 2, 3, 0, 5, 4]` with cost $n = 6$ that does **not** correspond to a valid Hamiltonian circuit. When extracted back to HC, edges $2→3$ and $0→5$ don't exist → `Or(false)`.

## Fix

Change connector edge lengths from **0 to 1**. This ensures:

- **Adjacent vertices** (direct connector edge): connector cost = 1
- **Non-adjacent vertices** (no direct connector): connector cost ≥ 2, because from an out-node $2i+1$ to a non-adjacent in-node $2j$, one step reaches an in-node $2v$ (neighbor of $i$), and reaching another in-node $2j$ from there requires at least two more steps through the bipartite out/in structure.

**Correctness proof for all graphs:**

| Condition | Optimal SC cost | Reasoning |
|-----------|----------------|-----------|
| HC exists | $2n$ | $n$ arcs × 1 + $n$ single-hop connectors × 1 |
| HC does not exist | $≥ 2n + 1$ | Every permutation has at least one non-adjacent pair (cost ≥ 2), so total connector cost ≥ $n + 1$ |

Since every optimal permutation at cost $2n$ must use only single-hop connectors (each costing exactly 1), **every optimal SC permutation maps back to a valid HC**. The `extract_solution` identity mapping is therefore correct.

## Changes

- `src/rules/hamiltoniancircuit_stackercrane.rs` — connector edge lengths 0 → 1, updated doc comments
- `src/unit_tests/rules/hamiltoniancircuit_stackercrane.rs` — updated expected costs ($n → 2n$), added prism graph regression test

## Test plan

- [x] All existing HC→SC unit tests updated and passing
- [x] New prism graph regression test (`test_hamiltoniancircuit_to_stackercrane_prism_graph`)
- [x] CLI reproduction: `pred reduce --to StackerCrane | pred solve` now returns `Or(true)` on prism graph
- [x] Full test suite with `example-db` and `ilp` features passing (3657 tests)
- [x] clippy + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
