### PR TITLE
Fix #109: [Rule] LongestCommonSubsequence → MaximumIndependentSet

### DIFF
--- a/docs/plans/2026-03-28-lcs-to-mis.md
+++ b/docs/plans/2026-03-28-lcs-to-mis.md
@@ -1,0 +1,88 @@
+# Plan: LongestCommonSubsequence -> MaximumIndependentSet Reduction
+
+**Issue:** #109
+**Type:** [Rule]
+**References:** Apostolico & Guerra 1987 (DOI: 10.1007/BF01840365), Santini et al. 2021 (DOI: 10.1016/j.cor.2020.105089)
+
+## Batch 1: Implementation (add-rule Steps 1-4)
+
+### Step 1: Add `cross_frequency_product()` getter to LCS model
+
+File: `src/models/misc/longest_common_subsequence.rs`
+
+Add a new getter method:
+```rust
+pub fn cross_frequency_product(&self) -> usize {
+    (0..self.alphabet_size)
+        .map(|c| {
+            self.strings
+                .iter()
+                .map(|s| s.iter().filter(|&&sym| sym == c).count())
+                .product::<usize>()
+        })
+        .sum()
+}
+```
+
+This computes the exact number of match-node vertices in the reduction graph.
+
+### Step 2: Implement the reduction rule
+
+File: `src/rules/longestcommonsubsequence_maximumindependentset.rs`
+
+**Algorithm:**
+1. Build match nodes: For each character c in 0..alphabet_size, enumerate all k-tuples of positions (p1, ..., pk) where s_i[p_i] = c for all i. Each tuple is a vertex.
+2. Build conflict edges: Two nodes u=(a1,...,ak) and v=(b1,...,bk) conflict if they cannot both appear in a valid common subsequence -- i.e., NOT(all a_i < b_i) AND NOT(all a_i > b_i).
+3. Target: `MaximumIndependentSet<SimpleGraph, One>` with unit weights.
+4. Solution extraction: Map MIS back to LCS by sorting selected nodes by position and reading off characters. The result is a padded config of length max_length.
+
+**Overhead:**
+- `num_vertices = "cross_frequency_product"`
+- `num_edges = "cross_frequency_product ^ 2"` (worst-case)
+
+**ReductionResult struct** stores:
+- target MIS problem
+- node_tuples: Vec of (character, positions) for extraction
+- max_length: for padding the extracted solution
+
+### Step 3: Register in mod.rs
+
+Add `pub(crate) mod longestcommonsubsequence_maximumindependentset;` to `src/rules/mod.rs`.
+
+### Step 4: Write unit tests
+
+File: `src/unit_tests/rules/longestcommonsubsequence_maximumindependentset.rs`
+
+Tests:
+1. `test_longestcommonsubsequence_to_maximumindependentset_closed_loop` - Use the ABAC/BACA example from the issue (k=2, LCS=3="BAC")
+2. `test_lcs_to_mis_three_strings` - k=3 strings
+3. `test_lcs_to_mis_single_char_alphabet` - Degenerate case
+4. `test_lcs_to_mis_structure` - Verify graph size matches cross_frequency_product
+
+### Step 5: Add canonical example to example_db
+
+File: `src/example_db/rule_builders.rs` (add to `canonical_rule_example_specs` list in `src/rules/longestcommonsubsequence_maximumindependentset.rs`)
+
+Use the ABAC/BACA example: 2 strings, alphabet {A,B,C} -> {0,1,2}, 6 match nodes, 9 conflict edges, MIS of size 3.
+
+### Step 6: Register example_db in mod.rs
+
+Add the `specs.extend(longestcommonsubsequence_maximumindependentset::canonical_rule_example_specs());` line to `src/rules/mod.rs`.
+
+## Batch 2: Paper entry (add-rule Step 5)
+
+### Step 7: Write paper entry
+
+File: `docs/paper/reductions.typ`
+
+Add a `reduction-rule("LongestCommonSubsequence", "MaximumIndependentSet", ...)` entry after the LCS problem-def section. Include worked example with the ABAC/BACA instance.
+
+### Step 8: Regenerate exports and verify
+
+```bash
+cargo run --example export_graph
+cargo run --example export_schemas
+make regenerate-fixtures
+make test clippy
+make paper
+```


### PR DESCRIPTION
## Summary
Add reduction rule from LongestCommonSubsequence to MaximumIndependentSet via match-node conflict graph construction (Apostolico & Guerra 1987; Santini et al. 2021).

Fixes #109
