### PR TITLE
fix paper completeness check false warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,22 @@ This project draws inspiration from the following packages:
 - **[A Compendium of NP Optimization Problems](https://www.csc.kth.se/tcs/compendium/)** — Online catalog of NP optimization problems with approximability results (Crescenzi & Kann).
 - **Computers and Intractability** (Garey & Johnson, 1979) — The classic reference cataloging 300+ NP-complete problems with reductions. The most cited book in computer science.
 
+## Citation
+
+If you find this project useful in your research, please cite:
+
+```bibtex
+@misc{pan2026problemreductionsscaleagentic,
+      title={Problem Reductions at Scale: Agentic Integration of Computationally Hard Problems}, 
+      author={Xi-Wei Pan and Shi-Wen An and Jin-Guo Liu},
+      year={2026},
+      eprint={2604.11535},
+      archivePrefix={arXiv},
+      primaryClass={cs.AI},
+      url={https://arxiv.org/abs/2604.11535}, 
+}
+```
+
 ## License
 
 MIT License - see [LICENSE](LICENSE) for details.

--- a/docs/paper/reductions.typ
+++ b/docs/paper/reductions.typ
@@ -607,7 +607,7 @@
     #super[2]Institute of Science Tokyo #h(0.3em) #super[3]RIKEN
   ]
   #v(1.5em)
-  #text(size: 10pt, style: "italic")[arXiv:2604.11535]
+  #text(size: 10pt, style: "italic")[#link("https://arxiv.org/abs/2604.11535")[arXiv:2604.11535]]
   #v(0.3em)
   #text(size: 10pt, style: "italic", fill: blue)[#link("https://github.com/CodingThrust/problem-reductions")[github.com/CodingThrust/problem-reductions]]
   #v(1.5em)

--- a/docs/paper/reductions.typ
+++ b/docs/paper/reductions.typ
@@ -607,7 +607,7 @@
     #super[2]Institute of Science Tokyo #h(0.3em) #super[3]RIKEN
   ]
   #v(1.5em)
-  #text(size: 10pt, style: "italic")[arXiv:2604.xxxxx]
+  #text(size: 10pt, style: "italic")[arXiv:2604.11535]
   #v(0.3em)
   #text(size: 10pt, style: "italic", fill: blue)[#link("https://github.com/CodingThrust/problem-reductions")[github.com/CodingThrust/problem-reductions]]
   #v(1.5em)

--- a/docs/paper/reductions.typ
+++ b/docs/paper/reductions.typ
@@ -15027,7 +15027,7 @@ Problems parameterized by graph type, weight type, or clause-width ($k$) admit i
 
 // Completeness check: warn about reduction rules in JSON but missing from paper
 #context {
-  let covered = covered-rules.get()
+  let covered = covered-rules.final()
   let json-edges = {
     let edges = graph-data.edges.map(e => (graph-data.nodes.at(e.source).name, graph-data.nodes.at(e.target).name))
     let unique = ()


### PR DESCRIPTION
## Summary
- Fix completeness check using `covered-rules.get()` which only sees state before the current location
- Changed to `covered-rules.final()` to see all rules in the document
- Eliminates false warning about 4 "missing" rules that were actually defined later in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)