### PR TITLE
Make MIS → KingsSubgraph reduction deterministic (#1061)

### DIFF
--- a/src/rules/unitdiskmapping/pathdecomposition.rs
+++ b/src/rules/unitdiskmapping/pathdecomposition.rs
@@ -14,15 +14,30 @@
 //! Experimental evaluation of a branch and bound algorithm for computing pathwidth.
 //! <https://doi.org/10.1007/978-3-319-07959-2_5>
 
+use rand::rngs::SmallRng;
 use rand::seq::IndexedRandom;
-use std::collections::{HashMap, HashSet};
+use rand::SeedableRng;
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+/// Default seed used when no explicit seed is passed to [`pathwidth`].
+///
+/// Keeping a fixed default makes [`pathwidth`] and [`greedy_decompose`] deterministic
+/// across repeated invocations with the same input, which reductions and downstream
+/// benchmarks rely on for reproducibility. Callers that want diverse layouts can use
+/// [`pathwidth_with_seed`] instead.
+pub const DEFAULT_PATHWIDTH_SEED: u64 = 0;
 
 /// Adjacency list representation built once from an edge list.
-type AdjList = Vec<HashSet<usize>>;
+///
+/// Uses `BTreeSet` rather than `HashSet` so iteration order is deterministic
+/// (sorted by vertex index). Several places in this module push from `adj[v]`
+/// into the layout's neighbor list; HashSet iteration order leaked into the
+/// vertex ordering and caused non-reproducible path decompositions.
+type AdjList = Vec<BTreeSet<usize>>;
 
 /// Build an adjacency list from an edge list.
 fn build_adj(num_vertices: usize, edges: &[(usize, usize)]) -> AdjList {
-    let mut adj: Vec<HashSet<usize>> = vec![HashSet::new(); num_vertices];
+    let mut adj: AdjList = vec![BTreeSet::new(); num_vertices];
     for &(u, v) in edges {
         adj[u].insert(v);
         adj[v].insert(u);
@@ -258,8 +273,14 @@ fn greedy_exact(adj: &AdjList, mut layout: Layout) -> Layout {
 
 /// Perform one greedy step by choosing the best vertex from a list.
 ///
-/// Selects randomly among vertices that minimize the new vsep.
-fn greedy_step(adj: &AdjList, layout: &Layout, list: &[usize]) -> Layout {
+/// Selects among vertices that minimize the new vsep, breaking ties using the
+/// provided RNG. Passing an explicit RNG makes tie-breaking deterministic given a seed.
+fn greedy_step<R: rand::Rng + ?Sized>(
+    adj: &AdjList,
+    layout: &Layout,
+    list: &[usize],
+    rng: &mut R,
+) -> Layout {
     let layouts: Vec<Layout> = list.iter().map(|&v| extend(adj, layout, v)).collect();
 
     let costs: Vec<usize> = layouts.iter().map(|l| l.vsep()).collect();
@@ -272,17 +293,33 @@ fn greedy_step(adj: &AdjList, layout: &Layout, list: &[usize]) -> Layout {
         .map(|(i, _)| i)
         .collect();
 
-    let mut rng = rand::rng();
-    let &chosen_idx = best_indices.as_slice().choose(&mut rng).unwrap();
+    let &chosen_idx = best_indices.as_slice().choose(rng).unwrap();
 
     layouts.into_iter().nth(chosen_idx).unwrap()
 }
 
 /// Compute a path decomposition using the greedy algorithm.
 ///
-/// This combines exact rules (that don't increase pathwidth) with
-/// greedy choices when exact rules don't apply.
+/// Uses a fixed default seed (see [`DEFAULT_PATHWIDTH_SEED`]) so repeated calls on
+/// the same input produce the same layout. Use [`pathwidth_with_seed`] for variation.
+///
+/// Only exposed for unit tests; production code reaches the greedy path through
+/// [`pathwidth`] or [`pathwidth_with_seed`].
+#[cfg(test)]
 pub fn greedy_decompose(num_vertices: usize, edges: &[(usize, usize)]) -> Layout {
+    let mut rng = SmallRng::seed_from_u64(DEFAULT_PATHWIDTH_SEED);
+    greedy_decompose_with_rng(num_vertices, edges, &mut rng)
+}
+
+/// Compute a path decomposition using the greedy algorithm with a caller-supplied RNG.
+///
+/// This combines exact rules (that don't increase pathwidth) with greedy choices
+/// when exact rules don't apply. Random tie-breaking draws from `rng`.
+fn greedy_decompose_with_rng<R: rand::Rng + ?Sized>(
+    num_vertices: usize,
+    edges: &[(usize, usize)],
+    rng: &mut R,
+) -> Layout {
     let adj = build_adj(num_vertices, edges);
     let mut layout = Layout::empty(num_vertices);
 
@@ -290,9 +327,9 @@ pub fn greedy_decompose(num_vertices: usize, edges: &[(usize, usize)]) -> Layout
         layout = greedy_exact(&adj, layout);
 
         if !layout.neighbors.is_empty() {
-            layout = greedy_step(&adj, &layout, &layout.neighbors.clone());
+            layout = greedy_step(&adj, &layout, &layout.neighbors.clone(), rng);
         } else if !layout.disconnected.is_empty() {
-            layout = greedy_step(&adj, &layout, &layout.disconnected.clone());
+            layout = greedy_step(&adj, &layout, &layout.disconnected.clone(), rng);
         } else {
             break;
         }
@@ -424,6 +461,23 @@ pub fn pathwidth(
     edges: &[(usize, usize)],
     method: PathDecompositionMethod,
 ) -> Layout {
+    pathwidth_with_seed(num_vertices, edges, method, DEFAULT_PATHWIDTH_SEED)
+}
+
+/// Like [`pathwidth`], but with a caller-chosen RNG seed for greedy tie-breaking.
+///
+/// The greedy path-decomposition algorithm uses random choices to break ties
+/// between candidate vertices with the same vertex separation. A single `SmallRng`
+/// seeded with `seed` is threaded through all restarts, so restarts remain diverse
+/// (each advances the RNG state) while the overall output is reproducible.
+///
+/// `MinhThiTrick` and `Auto` on small graphs are deterministic and ignore the seed.
+pub fn pathwidth_with_seed(
+    num_vertices: usize,
+    edges: &[(usize, usize)],
+    method: PathDecompositionMethod,
+    seed: u64,
+) -> Layout {
     let method = match method {
         PathDecompositionMethod::Auto => {
             if num_vertices > 30 {
@@ -438,9 +492,10 @@ pub fn pathwidth(
         PathDecompositionMethod::Greedy { nrepeat } => {
             // Defend against direct enum construction with nrepeat = 0.
             let nrepeat = nrepeat.max(1);
+            let mut rng = SmallRng::seed_from_u64(seed);
             let mut best: Option<Layout> = None;
             for _ in 0..nrepeat {
-                let layout = greedy_decompose(num_vertices, edges);
+                let layout = greedy_decompose_with_rng(num_vertices, edges, &mut rng);
                 if best.is_none() || layout.vsep() < best.as_ref().unwrap().vsep() {
                     best = Some(layout);
                 }

--- a/src/unit_tests/rules/maximumindependentset_gridgraph.rs
+++ b/src/unit_tests/rules/maximumindependentset_gridgraph.rs
@@ -33,6 +33,46 @@ fn test_map_unweighted_produces_uniform_weights() {
 }
 
 #[test]
+fn test_mis_simple_one_to_kings_one_is_deterministic_on_large_graph() {
+    // Regression for #1061: `pred reduce` output was non-deterministic because the
+    // greedy path decomposition used an unseeded thread RNG for tie-breaking and
+    // the adjacency list used HashSet iteration order. A 64-vertex graph matches
+    // the reporter's scenario (10x10 kings, p=0.3) and forces the Auto path to
+    // pick the Greedy branch (>30 vertices).
+    let n = 64;
+    let mut edges: Vec<(usize, usize)> = Vec::new();
+    for r in 0..8 {
+        for c in 0..8 {
+            let v = r * 8 + c;
+            if c + 1 < 8 {
+                edges.push((v, r * 8 + c + 1));
+            }
+            if r + 1 < 8 {
+                edges.push((v, (r + 1) * 8 + c));
+            }
+            if r + 1 < 8 && c + 1 < 8 {
+                edges.push((v, (r + 1) * 8 + c + 1));
+            }
+        }
+    }
+
+    let problem = MaximumIndependentSet::new(SimpleGraph::new(n, edges), vec![One; n]);
+
+    let first = ReduceTo::<MaximumIndependentSet<KingsSubgraph, One>>::reduce_to(&problem);
+    let baseline_atoms = first.target_problem().graph().num_vertices();
+    let baseline_edges = first.target_problem().graph().edges().len();
+
+    for _ in 0..3 {
+        let again = ReduceTo::<MaximumIndependentSet<KingsSubgraph, One>>::reduce_to(&problem);
+        assert_eq!(
+            again.target_problem().graph().num_vertices(),
+            baseline_atoms,
+        );
+        assert_eq!(again.target_problem().graph().edges().len(), baseline_edges);
+    }
+}
+
+#[test]
 fn test_mis_simple_one_to_kings_one_closed_loop() {
     // Path graph: 0-1-2-3-4 (MIS = 3: select vertices 0, 2, 4)
     let problem = MaximumIndependentSet::new(

--- a/src/unit_tests/rules/maximumindependentset_triangular.rs
+++ b/src/unit_tests/rules/maximumindependentset_triangular.rs
@@ -4,6 +4,44 @@ use crate::topology::{Graph, SimpleGraph, TriangularSubgraph};
 use crate::types::One;
 
 #[test]
+fn test_mis_simple_one_to_triangular_is_deterministic_on_large_graph() {
+    // Regression for #1061: the triangular mapping shares the same greedy
+    // path decomposition as the KSG mapping, so it had the same non-determinism
+    // (unseeded RNG + HashSet iteration order in `adj`). A 64-vertex graph
+    // forces `pathwidth` to pick the Greedy branch.
+    let n = 64;
+    let mut edges: Vec<(usize, usize)> = Vec::new();
+    for r in 0..8 {
+        for c in 0..8 {
+            let v = r * 8 + c;
+            if c + 1 < 8 {
+                edges.push((v, r * 8 + c + 1));
+            }
+            if r + 1 < 8 {
+                edges.push((v, (r + 1) * 8 + c));
+            }
+            if r + 1 < 8 && c + 1 < 8 {
+                edges.push((v, (r + 1) * 8 + c + 1));
+            }
+        }
+    }
+
+    let problem = MaximumIndependentSet::new(SimpleGraph::new(n, edges), vec![One; n]);
+    let first = ReduceTo::<MaximumIndependentSet<TriangularSubgraph, i32>>::reduce_to(&problem);
+    let baseline_atoms = first.target_problem().graph().num_vertices();
+    let baseline_edges = first.target_problem().graph().edges().len();
+
+    for _ in 0..3 {
+        let again = ReduceTo::<MaximumIndependentSet<TriangularSubgraph, i32>>::reduce_to(&problem);
+        assert_eq!(
+            again.target_problem().graph().num_vertices(),
+            baseline_atoms,
+        );
+        assert_eq!(again.target_problem().graph().edges().len(), baseline_edges);
+    }
+}
+
+#[test]
 fn test_mis_simple_one_to_triangular_closed_loop() {
     // Path graph: 0-1-2
     let problem =

--- a/src/unit_tests/rules/unitdiskmapping/pathdecomposition.rs
+++ b/src/unit_tests/rules/unitdiskmapping/pathdecomposition.rs
@@ -219,6 +219,66 @@ fn test_pathwidth_auto_large() {
     assert_eq!(layout.vsep(), 1); // Path graph has pathwidth 1
 }
 
+#[test]
+fn test_pathwidth_greedy_is_deterministic() {
+    // Reproduces issue #1061: pathwidth greedy must be deterministic across calls.
+    // Graph is large enough that Auto picks Greedy and tie-breaking in greedy_step
+    // is exercised (grid with many symmetric choices).
+    let n = 64;
+    let mut edges: Vec<(usize, usize)> = Vec::new();
+    for r in 0..8 {
+        for c in 0..8 {
+            let v = r * 8 + c;
+            if c + 1 < 8 {
+                edges.push((v, r * 8 + c + 1));
+            }
+            if r + 1 < 8 {
+                edges.push((v, (r + 1) * 8 + c));
+            }
+        }
+    }
+
+    let first = pathwidth(n, &edges, PathDecompositionMethod::Auto);
+    for _ in 0..3 {
+        let other = pathwidth(n, &edges, PathDecompositionMethod::Auto);
+        assert_eq!(other.vertices, first.vertices);
+        assert_eq!(other.vsep(), first.vsep());
+    }
+}
+
+#[test]
+fn test_pathwidth_with_seed_varies_output() {
+    // Different seeds may produce different layouts (same pathwidth or better/worse).
+    // This verifies the seed API actually affects tie-breaking.
+    let n = 64;
+    let mut edges: Vec<(usize, usize)> = Vec::new();
+    for r in 0..8 {
+        for c in 0..8 {
+            let v = r * 8 + c;
+            if c + 1 < 8 {
+                edges.push((v, r * 8 + c + 1));
+            }
+            if r + 1 < 8 {
+                edges.push((v, (r + 1) * 8 + c));
+            }
+        }
+    }
+
+    let method = PathDecompositionMethod::greedy();
+    let a = pathwidth_with_seed(n, &edges, method, 0);
+    let b = pathwidth_with_seed(n, &edges, method, 0);
+    assert_eq!(a.vertices, b.vertices, "same seed → same layout");
+
+    // At least one of the sampled seeds should produce a different ordering,
+    // confirming the seed actually threads into tie-breaking.
+    let differs =
+        (1u64..=10).any(|s| pathwidth_with_seed(n, &edges, method, s).vertices != a.vertices);
+    assert!(
+        differs,
+        "expected some seed in 1..=10 to produce a different vertex ordering than seed 0",
+    );
+}
+
 // === Ground truth tests from JSON dataset ===
 
 /// Compute vsep from scratch for a given vertex ordering on a graph.


### PR DESCRIPTION
## Summary

Fixes #1061. `pred reduce` output for `MIS<SimpleGraph, One> → MIS<KingsSubgraph, One>` now produces byte-identical bundles across repeated invocations on the same input. Three `pred reduce` runs on a 64-vertex MIS used to vary ~15–20 % in atom/edge count; they now match exactly.

## Root cause

Two compounding sources of non-determinism in `src/rules/unitdiskmapping/pathdecomposition.rs`:

1. **Unseeded RNG** — `greedy_step` used `rand::rng()` (thread-local, OS-seeded) to pick among tied candidates. Compounded by `pathwidth`'s 10 random restarts for >30-vertex inputs.
2. **HashSet iteration order** — `AdjList` was `Vec<HashSet<usize>>`. When `vsep_updated_neighbors` did `for &w in &adj[v] { nbs.push(w); }`, per-process HashSet iteration order leaked into `layout.neighbors`, which then fed the next greedy step. Seeding the RNG alone was not enough (I hit this: same seed, different output — which is how I found this second source).

## Fix

- Change `AdjList` from `Vec<HashSet<usize>>` to `Vec<BTreeSet<usize>>` so iteration is deterministic (sorted).
- Thread a `SmallRng` through `greedy_step` / `greedy_decompose` / `pathwidth`, seeded from new `DEFAULT_PATHWIDTH_SEED = 0` so the public API is reproducible by default.
- Add `pathwidth_with_seed(.., seed)` as an escape hatch for callers that want to sample the layout space. Single `SmallRng` threads through all 10 restarts so each restart remains diverse (RNG state progresses) while overall output is reproducible given the seed.
- `reduce_to()` stays a pure function — no env vars, no global state, no trait changes.

## Non-goals (tracked separately)

- `--seed` flag on `pred reduce` — would require plumbing an optimization hyperparameter through `ReduceTo::reduce_to(&self)`; out of scope for a determinism fix.
- Sampling K seeds and picking minimum-atom mapping — opened as #1062.

## Tests

Three new tests (all passing):

- `test_pathwidth_greedy_is_deterministic` — 64-vertex grid graph, 4 `pathwidth` calls must yield identical vertex orderings and vsep.
- `test_pathwidth_with_seed_varies_output` — confirms seed actually threads into tie-breaking (same seed → same output; at least one seed in 1..=10 → different output).
- `test_mis_simple_one_to_kings_one_is_deterministic_on_large_graph` — end-to-end regression for the reporter's 64-vertex scenario; 4 `reduce_to` calls must agree on target `num_vertices` and `num_edges`.

Full suite: 4960 library tests + 316 CLI tests pass. `cargo clippy` and `cargo fmt --check` clean.

## Test plan

- [x] `cargo test --lib` (4960 pass, 0 fail)
- [x] `cargo test -p problemreductions-cli` (316 pass, 0 fail)
- [x] `cargo clippy --lib --all-features` clean
- [x] `cargo fmt --check` clean
- [x] Manual CLI repro: 3× `pred reduce` on 64-vertex MIS produce byte-identical `diff`-empty bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)