### PR TITLE
Align CBM serialized form with declared schema

### DIFF
--- a/problemreductions-cli/tests/cli_tests.rs
+++ b/problemreductions-cli/tests/cli_tests.rs
@@ -423,17 +423,15 @@ fn test_evaluate_sat() {
 }
 
 #[test]
-fn test_evaluate_consecutive_block_minimization_rejects_inconsistent_dimensions() {
+fn test_evaluate_consecutive_block_minimization_rejects_ragged_matrix() {
     let problem_json = r#"{
         "type": "ConsecutiveBlockMinimization",
         "data": {
-            "matrix": [[true]],
-            "num_rows": 1,
-            "num_cols": 2,
+            "matrix": [[true, false], [true]],
             "bound": 1
         }
     }"#;
-    let tmp = std::env::temp_dir().join("pred_test_eval_cbm_invalid_dims.json");
+    let tmp = std::env::temp_dir().join("pred_test_eval_cbm_ragged_matrix.json");
     std::fs::write(&tmp, problem_json).unwrap();
 
     let output = pred()
@@ -442,7 +440,7 @@ fn test_evaluate_consecutive_block_minimization_rejects_inconsistent_dimensions(
         .unwrap();
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("num_cols must match matrix column count"));
+    assert!(stderr.contains("same length"));
     assert!(!stderr.contains("panicked at"), "stderr: {stderr}");
     std::fs::remove_file(&tmp).ok();
 }

--- a/src/models/algebraic/consecutive_block_minimization.rs
+++ b/src/models/algebraic/consecutive_block_minimization.rs
@@ -58,7 +58,10 @@ inventory::submit! {
 /// }
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(try_from = "ConsecutiveBlockMinimizationDef")]
+#[serde(
+    try_from = "ConsecutiveBlockMinimizationDef",
+    into = "ConsecutiveBlockMinimizationDef"
+)]
 pub struct ConsecutiveBlockMinimization {
     /// The binary matrix A (m x n).
     matrix: Vec<Vec<bool>>,
@@ -184,11 +187,9 @@ crate::declare_variants! {
     default ConsecutiveBlockMinimization => "factorial(num_cols) * num_rows * num_cols",
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct ConsecutiveBlockMinimizationDef {
     matrix: Vec<Vec<bool>>,
-    num_rows: usize,
-    num_cols: usize,
     bound: i64,
 }
 
@@ -196,20 +197,16 @@ impl TryFrom<ConsecutiveBlockMinimizationDef> for ConsecutiveBlockMinimization {
     type Error = String;
 
     fn try_from(value: ConsecutiveBlockMinimizationDef) -> Result<Self, Self::Error> {
-        let problem = Self::try_new(value.matrix, value.bound)?;
-        if value.num_rows != problem.num_rows {
-            return Err(format!(
-                "num_rows must match matrix row count ({})",
-                problem.num_rows
-            ));
+        Self::try_new(value.matrix, value.bound)
+    }
+}
+
+impl From<ConsecutiveBlockMinimization> for ConsecutiveBlockMinimizationDef {
+    fn from(value: ConsecutiveBlockMinimization) -> Self {
+        Self {
+            matrix: value.matrix,
+            bound: value.bound,
         }
-        if value.num_cols != problem.num_cols {
-            return Err(format!(
-                "num_cols must match matrix column count ({})",
-                problem.num_cols
-            ));
-        }
-        Ok(problem)
     }
 }
 

--- a/src/unit_tests/models/algebraic/consecutive_block_minimization.rs
+++ b/src/unit_tests/models/algebraic/consecutive_block_minimization.rs
@@ -91,10 +91,20 @@ fn test_consecutive_block_minimization_serialization() {
 }
 
 #[test]
-fn test_consecutive_block_minimization_deserialization_rejects_inconsistent_dimensions() {
-    let json = r#"{"matrix":[[true]],"num_rows":1,"num_cols":2,"bound":1}"#;
+fn test_consecutive_block_minimization_serialization_omits_derived_fields() {
+    let problem = ConsecutiveBlockMinimization::new(vec![vec![true, false], vec![false, true]], 2);
+    let value: serde_json::Value = serde_json::to_value(&problem).unwrap();
+    let obj = value.as_object().unwrap();
+    assert_eq!(obj.len(), 2);
+    assert!(obj.contains_key("matrix"));
+    assert!(obj.contains_key("bound"));
+}
+
+#[test]
+fn test_consecutive_block_minimization_deserialization_rejects_ragged_matrix() {
+    let json = r#"{"matrix":[[true,false],[true]],"bound":1}"#;
     let err = serde_json::from_str::<ConsecutiveBlockMinimization>(json).unwrap_err();
-    assert!(err.to_string().contains("num_cols"));
+    assert!(err.to_string().contains("same length"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`ConsecutiveBlockMinimization`'s `ProblemSchemaEntry::fields` declares only `matrix` and `bound`, but the model's serde was inconsistent with that declaration:

- `Serialize` wrote 4 fields (`matrix`, `num_rows`, `num_cols`, `bound`) via the default field-by-field derive
- `Deserialize` (via `try_from = ConsecutiveBlockMinimizationDef`) **required** `num_rows` and `num_cols` to be present, even though they're fully derivable from `matrix`

That inconsistency broke the schema-driven `pred create` path: it builds JSON from the declared schema fields (matrix + bound), then validates by deserializing — which failed with `Schema-driven factory rejected generated data for ConsecutiveBlockMinimization: missing field 'num_rows'`. Reproducer:

```
$ pred create CBM --matrix '[[true,false,true],[false,true,true]]' --bound-k 2
Error: Schema-driven factory rejected generated data for ConsecutiveBlockMinimization: missing field `num_rows`
```

## Fix

`num_rows` and `num_cols` are just `matrix.len()` and `matrix[0].len()` — they're cached for fast getter access but they're not independent data. Drop them from the wire format entirely by adding `serde(into = ConsecutiveBlockMinimizationDef)` so both directions round-trip through the minimal `{matrix, bound}` form. `try_new` already recomputes the cached dimensions on construction.

The previous validation that "if the JSON contains a num_rows that disagrees with the matrix, reject" was guarding against malformed input we shouldn't have been producing in the first place; the real input validation that survives is ragged-matrix rejection (in `validate_matrix_dimensions`), which is now what the test suite exercises.

## Verification

```
$ pred create CBM --matrix '[[true,false,true],[false,true,true]]' --bound-k 2 \
    | pred solve - --solver brute-force
{
  "evaluation": "Or(true)",
  "problem": "ConsecutiveBlockMinimization",
  "solution": [0, 2, 1],
  "solver": "brute-force"
}
```

## Test plan

- [x] `cargo test --lib` — 4958 passed (9 CBM-specific tests pass)
- [x] `cargo test --test main` — 75 integration tests passed
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --workspace -- -D warnings`
- [x] Manual end-to-end: `pred create CBM ... | pred solve` returns `Or(true)` with witness `[0, 2, 1]`

## Related

- #1064 swaps the README's broken CBM example for an MIS one. With this PR landed, the original CBM example would also work; #1064 still stands on its own merits (MIS is a more recognizable lead example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)