### PR TITLE
Fix CI regressions after Pareto search merge

### DIFF
--- a/examples/chained_reduction_factoring_to_spinglass.rs
+++ b/examples/chained_reduction_factoring_to_spinglass.rs
@@ -62,7 +62,7 @@ pub fn run() {
 
     // ANCHOR: overhead
     // Print per-edge overhead polynomials
-    let edge_overheads = graph.path_overheads(&rpath);
+    let edge_overheads = graph.path_overheads(rpath);
     for (i, overhead) in edge_overheads.iter().enumerate() {
         println!("{} → {}:", rpath.steps[i], rpath.steps[i + 1]);
         for (field, poly) in &overhead.output_size {
@@ -71,7 +71,7 @@ pub fn run() {
     }
 
     // Compose overheads symbolically along the full path
-    let composed = graph.compose_path_overhead(&rpath);
+    let composed = graph.compose_path_overhead(rpath);
     println!("Composed (source → target):");
     for (field, poly) in &composed.output_size {
         println!("  {} = {}", field, poly);

--- a/src/unit_tests/example_db.rs
+++ b/src/unit_tests/example_db.rs
@@ -587,27 +587,35 @@ fn rule_specs_solution_pairs_are_consistent() {
         )
         .unwrap_or_else(|e| panic!("Failed to load target for {label}: {e}"));
 
-        // Try witness path first; fall back to aggregate for aggregate-only edges.
-        // Some authored direct reductions are proof-only and intentionally have
-        // no runtime capability in any mode.
-        let witness_paths = graph.find_all_paths(
-            &example.source.problem,
-            &example.source.variant,
-            &example.target.problem,
-            &example.target.variant,
-        );
-        if witness_paths.is_empty() {
-            let aggregate_paths = graph.find_all_paths_mode(
+        // Inspect the authored direct reduction. Indirect paths between the same
+        // problem variants do not implement this rule's stored solution pairs.
+        let witness_path = graph
+            .find_all_paths(
                 &example.source.problem,
                 &example.source.variant,
                 &example.target.problem,
                 &example.target.variant,
-                crate::rules::ReductionMode::Aggregate,
-            );
-            if aggregate_paths.is_empty() {
+            )
+            .into_iter()
+            .find(|path| path.len() == 1);
+        if witness_path.is_none() {
+            let has_aggregate_path = graph
+                .find_all_paths_mode(
+                    &example.source.problem,
+                    &example.source.variant,
+                    &example.target.problem,
+                    &example.target.variant,
+                    crate::rules::ReductionMode::Aggregate,
+                )
+                .iter()
+                .any(|path| path.len() == 1);
+            if !has_aggregate_path {
                 assert!(
-                    graph.has_direct_reduction_by_name(&example.source.problem, &example.target.problem),
-                    "No reduction path (witness or aggregate) or direct proof-only edge for {label}"
+                    graph.has_direct_reduction_by_name(
+                        &example.source.problem,
+                        &example.target.problem
+                    ),
+                    "No direct witness, aggregate, or proof-only reduction for {label}"
                 );
                 assert!(
                     !graph.has_direct_reduction_by_name_mode(
@@ -629,7 +637,9 @@ fn rule_specs_solution_pairs_are_consistent() {
         }
 
         // Only do witness round-trip when a witness path exists
-        let chain = witness_path.and_then(|path| graph.reduce_along_path(&path, source.as_any()));
+        let chain = witness_path
+            .as_ref()
+            .and_then(|path| graph.reduce_along_path(path, source.as_any()));
 
         for pair in &example.solutions {
             // Verify config lengths match problem dimensions

--- a/src/unit_tests/rules/pareto.rs
+++ b/src/unit_tests/rules/pareto.rs
@@ -1379,15 +1379,15 @@ fn test_pareto_search_matches_independent_small_graph_oracle() {
         let mut adjacency = vec![Vec::new(); nodes];
         let mut edges = Vec::new();
         for source in 0..nodes - 1 {
-            for target in source + 1..nodes {
+            for (target, target_name) in NAMES.iter().enumerate().take(nodes).skip(source + 1) {
                 state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
-                if target == source + 1 || state % 3 == 0 {
+                if target == source + 1 || state.is_multiple_of(3) {
                     let a = ((state >> 8) % 9 + 1) as usize;
                     let b = ((state >> 16) % 9 + 1) as usize;
                     adjacency[source].push((target, a, b));
                     edges.push((
                         NAMES[source],
-                        NAMES[target],
+                        *target_name,
                         growth_edge(vec![
                             ("a", Expr::Const(a as f64)),
                             ("b", Expr::Const(b as f64)),


### PR DESCRIPTION
## Why CI failed

The Pareto refactor left one stale single-path variable in the example-db test, while the example and differential fixture also triggered Clippy errors under the CI toolchain.

## Fix

- inspect only the authored direct witness edge for each example-db rule; indirect paths are not substitutes for that rule’s stored solution pairs
- keep aggregate/proof-only capability checks explicit when no direct witness edge exists
- remove redundant references in the chained reduction example
- update the small differential oracle fixture for current Clippy rules

This does not restore a winner-selection API, a best-path recommendation, or a compatibility fallback.

## Verification

- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo check --workspace --tests --features "ilp-highs example-db"`
- `CARGO_BUILD_JOBS=1 cargo clippy --all-targets --features ilp-highs -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo test -p problemreductions --lib --features "ilp-highs example-db" rule_specs_solution_pairs_are_consistent -- --test-threads=1`
- `CARGO_BUILD_JOBS=1 cargo test -p problemreductions --lib --features ilp-highs test_pareto_search_matches_independent_small_graph_oracle -- --test-threads=1`

## Scope

Three files only. No resource model, search contract, CLI surface, or public API changes.