### PR TITLE
Add exact symbolic SizeMap contracts

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -3,7 +3,9 @@
 pub use num_bigint::BigInt;
 use num_rational::BigRational;
 use num_traits::{FromPrimitive, ToPrimitive};
-pub use problemreductions_expr::{Expr, ExprNode, ExprNodeId, ParseError, SubstitutionError};
+pub use problemreductions_expr::{
+    Expr, ExprNode, ExprNodeId, ParseError, SubstitutionError, Symbol,
+};
 use std::collections::HashMap;
 use std::fmt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub mod error;
 #[cfg(feature = "example-db")]
 pub mod example_db;
 pub mod export;
-pub(crate) mod expr;
+pub mod expr;
 // The growth domain backs `big_o_normal_form` (M2) and the asymptotic Pareto path
 // search (`GrowthLabel`, M3/F3a). `Growth` is re-exported for CLI/MCP consumers that
 // render or serialize the asymptotic front.
@@ -34,6 +34,7 @@ pub mod io;
 pub mod models;
 pub mod registry;
 pub mod rules;
+pub mod size_map;
 pub mod solvers;
 pub mod topology;
 pub mod traits;

--- a/src/size_map.rs
+++ b/src/size_map.rs
@@ -1,0 +1,468 @@
+//! Exact symbolic maps between problem-size vectors.
+
+use crate::expr::{Expr, ExprNode, ExprNodeId, Symbol};
+use crate::types::ProblemSize;
+use num_bigint::{BigInt, BigUint, Sign};
+use num_traits::{One, Signed, Zero};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+/// A validated exact mapping from source size fields to target size fields.
+#[derive(Clone, Debug)]
+pub struct SizeMap {
+    edge: Box<str>,
+    fields: Vec<SizeMapField>,
+}
+
+#[derive(Clone, Debug)]
+struct SizeMapField {
+    name: Box<str>,
+    expression: Expr,
+    plan: ExactPlan,
+}
+
+#[derive(Clone, Debug)]
+struct ExactPlan(Arc<ExactPlanNode>);
+
+#[derive(Debug)]
+enum ExactPlanNode {
+    Const(BigInt),
+    Var(Symbol),
+    Add(Box<[ExactPlan]>),
+    Mul(Box<[ExactPlan]>),
+    Div(ExactPlan, ExactPlan),
+    Pow(ExactPlan, BigUint),
+}
+
+impl ExactPlan {
+    fn identity(&self) -> usize {
+        Arc::as_ptr(&self.0) as usize
+    }
+}
+
+impl SizeMap {
+    /// Validate and compile exact expressions for one reduction edge.
+    pub fn new<I, N>(edge: impl Into<Box<str>>, fields: I) -> Result<Self, SizeMapError>
+    where
+        I: IntoIterator<Item = (N, Expr)>,
+        N: Into<Box<str>>,
+    {
+        let edge = edge.into();
+        let mut names = HashSet::new();
+        let mut plans = HashMap::new();
+        let mut compiled_fields = Vec::new();
+        for (name, expression) in fields {
+            let name = name.into();
+            if let Err(error) = Symbol::new(name.clone()) {
+                return Err(SizeMapError::InvalidTargetField {
+                    edge,
+                    field: name,
+                    reason: error.to_string().into(),
+                });
+            }
+            if !names.insert(name.clone()) {
+                return Err(SizeMapError::DuplicateTargetField { edge, field: name });
+            }
+            let plan = compile_expression(&expression, &mut plans).map_err(|error| {
+                validation_error(edge.clone(), name.clone(), expression.to_string(), error)
+            })?;
+            compiled_fields.push(SizeMapField {
+                name,
+                expression,
+                plan,
+            });
+        }
+        Ok(Self {
+            edge,
+            fields: compiled_fields,
+        })
+    }
+
+    /// The reduction edge named in all errors from this map.
+    pub fn edge(&self) -> &str {
+        &self.edge
+    }
+
+    /// Exact expressions in deterministic target-field order.
+    pub fn expressions(&self) -> impl Iterator<Item = (&str, &Expr)> {
+        self.fields
+            .iter()
+            .map(|field| (field.name.as_ref(), &field.expression))
+    }
+
+    /// Return the exact expression for a target field.
+    pub fn get(&self, target_field: &str) -> Option<&Expr> {
+        self.fields
+            .iter()
+            .find(|field| field.name.as_ref() == target_field)
+            .map(|field| &field.expression)
+    }
+
+    /// Evaluate every target field exactly and convert each result to `usize`.
+    pub fn evaluate(&self, input: &ProblemSize) -> Result<ProblemSize, SizeMapError> {
+        let mut memo = HashMap::new();
+        let mut output = Vec::with_capacity(self.fields.len());
+        for field in &self.fields {
+            let value =
+                evaluate_plan(&field.plan, input, &mut memo).map_err(|error| match error {
+                    EvaluationFailure::MissingInputField(input_field) => {
+                        SizeMapError::MissingInputField {
+                            edge: self.edge.clone(),
+                            target_field: field.name.clone(),
+                            input_field,
+                        }
+                    }
+                    EvaluationFailure::DivisionByZero => SizeMapError::DivisionByZero {
+                        edge: self.edge.clone(),
+                        target_field: field.name.clone(),
+                    },
+                    EvaluationFailure::NonIntegralDivision {
+                        numerator,
+                        denominator,
+                    } => SizeMapError::NonIntegralResult {
+                        edge: self.edge.clone(),
+                        target_field: field.name.clone(),
+                        value: format!("{numerator}/{denominator}").into(),
+                    },
+                })?;
+            if value.is_negative() {
+                return Err(SizeMapError::NegativeResult {
+                    edge: self.edge.clone(),
+                    target_field: field.name.clone(),
+                    value,
+                });
+            }
+            let concrete = usize::try_from(&value).map_err(|_| SizeMapError::OutputOutOfRange {
+                edge: self.edge.clone(),
+                target_field: field.name.clone(),
+                value,
+            })?;
+            output.push((field.name.as_ref(), concrete));
+        }
+        Ok(ProblemSize::new(output))
+    }
+
+    /// Compose two exact maps by canonical substitution.
+    pub fn compose(
+        &self,
+        next: &SizeMap,
+        composed_edge: impl Into<Box<str>>,
+    ) -> Result<SizeMap, SizeMapError> {
+        let composed_edge = composed_edge.into();
+        let replacements: HashMap<&str, &Expr> = self.expressions().collect();
+        let mut fields = Vec::with_capacity(next.fields.len());
+        for field in &next.fields {
+            let expression = field
+                .expression
+                .substitute_complete(&replacements)
+                .map_err(|error| SizeMapError::MissingCompositionInput {
+                    edge: composed_edge.clone(),
+                    target_field: field.name.clone(),
+                    input_fields: error.missing_variables().map(Box::<str>::from).collect(),
+                })?;
+            fields.push((field.name.clone(), expression));
+        }
+        Self::new(composed_edge, fields)
+    }
+}
+
+fn compile_expression(
+    expression: &Expr,
+    memo: &mut HashMap<ExprNodeId, ExactPlan>,
+) -> Result<ExactPlan, ValidationFailure> {
+    if let Some(plan) = memo.get(&expression.node_identity()) {
+        return Ok(plan.clone());
+    }
+    let node = match expression.node() {
+        ExprNode::Const(value) => {
+            if !value.is_integer() {
+                return Err(ValidationFailure::NonIntegralConstant(
+                    value.to_string().into(),
+                ));
+            }
+            ExactPlanNode::Const(value.to_integer())
+        }
+        ExprNode::Var(symbol) => ExactPlanNode::Var(symbol.clone()),
+        ExprNode::Add(values) => ExactPlanNode::Add(
+            values
+                .iter()
+                .map(|value| compile_expression(value, memo))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        ),
+        ExprNode::Mul(values) => return compile_product(expression, values, memo),
+        ExprNode::Pow(base, exponent) => {
+            let ExprNode::Const(exponent) = exponent.node() else {
+                return Err(ValidationFailure::NonIntegralConstantExponent(
+                    exponent.to_string().into(),
+                ));
+            };
+            if !exponent.is_integer() {
+                return Err(ValidationFailure::NonIntegralConstantExponent(
+                    exponent.to_string().into(),
+                ));
+            }
+            let exponent = exponent.to_integer();
+            if exponent.sign() == Sign::Minus {
+                ExactPlanNode::Div(
+                    constant_plan(BigInt::one()),
+                    power_plan(base, exponent.magnitude().clone(), memo)?,
+                )
+            } else {
+                ExactPlanNode::Pow(
+                    compile_expression(base, memo)?,
+                    exponent.magnitude().clone(),
+                )
+            }
+        }
+        ExprNode::Exp(_) => return Err(ValidationFailure::UnsupportedOperator("exp")),
+        ExprNode::Log(_) => return Err(ValidationFailure::UnsupportedOperator("log")),
+        ExprNode::Factorial(_) => return Err(ValidationFailure::UnsupportedOperator("factorial")),
+    };
+    let plan = ExactPlan(Arc::new(node));
+    memo.insert(expression.node_identity(), plan.clone());
+    Ok(plan)
+}
+
+fn compile_product(
+    expression: &Expr,
+    values: &[Expr],
+    memo: &mut HashMap<ExprNodeId, ExactPlan>,
+) -> Result<ExactPlan, ValidationFailure> {
+    let mut numerator = Vec::new();
+    let mut denominator = Vec::new();
+    for value in values {
+        if let ExprNode::Pow(base, exponent) = value.node() {
+            if let ExprNode::Const(exponent) = exponent.node() {
+                if exponent.is_integer() && exponent.is_negative() {
+                    denominator.push(power_plan(
+                        base,
+                        exponent.to_integer().magnitude().clone(),
+                        memo,
+                    )?);
+                    continue;
+                }
+            }
+        }
+        numerator.push(compile_expression(value, memo)?);
+    }
+    let plan = if denominator.is_empty() {
+        product_plan(numerator)
+    } else {
+        ExactPlan(Arc::new(ExactPlanNode::Div(
+            product_plan(numerator),
+            product_plan(denominator),
+        )))
+    };
+    memo.insert(expression.node_identity(), plan.clone());
+    Ok(plan)
+}
+
+fn power_plan(
+    base: &Expr,
+    exponent: BigUint,
+    memo: &mut HashMap<ExprNodeId, ExactPlan>,
+) -> Result<ExactPlan, ValidationFailure> {
+    Ok(ExactPlan(Arc::new(ExactPlanNode::Pow(
+        compile_expression(base, memo)?,
+        exponent,
+    ))))
+}
+
+fn product_plan(mut factors: Vec<ExactPlan>) -> ExactPlan {
+    match factors.len() {
+        0 => constant_plan(BigInt::one()),
+        1 => factors.remove(0),
+        _ => ExactPlan(Arc::new(ExactPlanNode::Mul(factors.into_boxed_slice()))),
+    }
+}
+
+fn constant_plan(value: BigInt) -> ExactPlan {
+    ExactPlan(Arc::new(ExactPlanNode::Const(value)))
+}
+
+fn evaluate_plan(
+    plan: &ExactPlan,
+    input: &ProblemSize,
+    memo: &mut HashMap<usize, BigInt>,
+) -> Result<BigInt, EvaluationFailure> {
+    if let Some(value) = memo.get(&plan.identity()) {
+        return Ok(value.clone());
+    }
+    let value = match plan.0.as_ref() {
+        ExactPlanNode::Const(value) => value.clone(),
+        ExactPlanNode::Var(symbol) => BigInt::from(
+            input
+                .get(symbol.as_str())
+                .ok_or_else(|| EvaluationFailure::MissingInputField(symbol.to_string().into()))?,
+        ),
+        ExactPlanNode::Add(values) => values.iter().try_fold(
+            BigInt::zero(),
+            |sum, value| -> Result<_, EvaluationFailure> {
+                Ok(sum + evaluate_plan(value, input, memo)?)
+            },
+        )?,
+        ExactPlanNode::Mul(values) => values.iter().try_fold(
+            BigInt::one(),
+            |product, value| -> Result<_, EvaluationFailure> {
+                Ok(product * evaluate_plan(value, input, memo)?)
+            },
+        )?,
+        ExactPlanNode::Div(numerator, denominator) => {
+            let numerator = evaluate_plan(numerator, input, memo)?;
+            let denominator = evaluate_plan(denominator, input, memo)?;
+            if denominator.is_zero() {
+                return Err(EvaluationFailure::DivisionByZero);
+            }
+            if (&numerator % &denominator) != BigInt::zero() {
+                return Err(EvaluationFailure::NonIntegralDivision {
+                    numerator,
+                    denominator,
+                });
+            }
+            numerator / denominator
+        }
+        ExactPlanNode::Pow(base, exponent) => {
+            pow_exact(evaluate_plan(base, input, memo)?, exponent)
+        }
+    };
+    memo.insert(plan.identity(), value.clone());
+    Ok(value)
+}
+
+fn pow_exact(mut base: BigInt, exponent: &BigUint) -> BigInt {
+    let mut exponent = exponent.clone();
+    let mut result = BigInt::one();
+    while !exponent.is_zero() {
+        if exponent.bit(0) {
+            result *= &base;
+        }
+        exponent >>= 1usize;
+        if !exponent.is_zero() {
+            base = &base * &base;
+        }
+    }
+    result
+}
+
+#[derive(Debug)]
+enum ValidationFailure {
+    NonIntegralConstant(Box<str>),
+    NonIntegralConstantExponent(Box<str>),
+    UnsupportedOperator(&'static str),
+}
+
+fn validation_error(
+    edge: Box<str>,
+    target_field: Box<str>,
+    expression: String,
+    failure: ValidationFailure,
+) -> SizeMapError {
+    match failure {
+        ValidationFailure::NonIntegralConstant(value) => SizeMapError::NonIntegralConstant {
+            edge,
+            target_field,
+            expression: expression.into(),
+            value,
+        },
+        ValidationFailure::NonIntegralConstantExponent(exponent) => {
+            SizeMapError::NonIntegralConstantExponent {
+                edge,
+                target_field,
+                expression: expression.into(),
+                exponent,
+            }
+        }
+        ValidationFailure::UnsupportedOperator(operator) => SizeMapError::UnsupportedOperator {
+            edge,
+            target_field,
+            expression: expression.into(),
+            operator,
+        },
+    }
+}
+
+#[derive(Debug)]
+enum EvaluationFailure {
+    MissingInputField(Box<str>),
+    DivisionByZero,
+    NonIntegralDivision {
+        numerator: BigInt,
+        denominator: BigInt,
+    },
+}
+
+/// Validation, composition, or exact-evaluation failure for a [`SizeMap`].
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum SizeMapError {
+    #[error("size map for edge {edge} has invalid target field {field:?}: {reason}")]
+    InvalidTargetField {
+        edge: Box<str>,
+        field: Box<str>,
+        reason: Box<str>,
+    },
+    #[error("size map for edge {edge} declares target field {field} more than once")]
+    DuplicateTargetField { edge: Box<str>, field: Box<str> },
+    #[error("size map for edge {edge}, target field {target_field}, contains non-integral constant {value} in {expression}")]
+    NonIntegralConstant {
+        edge: Box<str>,
+        target_field: Box<str>,
+        expression: Box<str>,
+        value: Box<str>,
+    },
+    #[error("size map for edge {edge}, target field {target_field}, requires a constant integral exponent, found {exponent} in {expression}")]
+    NonIntegralConstantExponent {
+        edge: Box<str>,
+        target_field: Box<str>,
+        expression: Box<str>,
+        exponent: Box<str>,
+    },
+    #[error("size map for edge {edge}, target field {target_field}, does not support {operator} in {expression}")]
+    UnsupportedOperator {
+        edge: Box<str>,
+        target_field: Box<str>,
+        expression: Box<str>,
+        operator: &'static str,
+    },
+    #[error("size map composition for edge {edge}, target field {target_field}, is missing intermediate fields {input_fields:?}")]
+    MissingCompositionInput {
+        edge: Box<str>,
+        target_field: Box<str>,
+        input_fields: Vec<Box<str>>,
+    },
+    #[error("size map for edge {edge}, target field {target_field}, is missing input field {input_field}")]
+    MissingInputField {
+        edge: Box<str>,
+        target_field: Box<str>,
+        input_field: Box<str>,
+    },
+    #[error("size map for edge {edge}, target field {target_field}, divides by zero")]
+    DivisionByZero {
+        edge: Box<str>,
+        target_field: Box<str>,
+    },
+    #[error("size map for edge {edge}, target field {target_field}, produced non-integral value {value}")]
+    NonIntegralResult {
+        edge: Box<str>,
+        target_field: Box<str>,
+        value: Box<str>,
+    },
+    #[error(
+        "size map for edge {edge}, target field {target_field}, produced negative value {value}"
+    )]
+    NegativeResult {
+        edge: Box<str>,
+        target_field: Box<str>,
+        value: BigInt,
+    },
+    #[error("size map for edge {edge}, target field {target_field}, produced value {value} outside the ProblemSize range")]
+    OutputOutOfRange {
+        edge: Box<str>,
+        target_field: Box<str>,
+        value: BigInt,
+    },
+}
+
+#[cfg(test)]
+#[path = "unit_tests/size_map.rs"]
+mod tests;

--- a/src/unit_tests/rules/maximumindependentset_maximumclique.rs
+++ b/src/unit_tests/rules/maximumindependentset_maximumclique.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::rules::test_helpers::assert_optimization_round_trip_from_optimization_target;
+use crate::size_map::SizeMap;
 use crate::solvers::BruteForce;
 use crate::traits::Problem;
-use crate::types::One;
+use crate::types::{One, ProblemSize};
 
 #[test]
 fn test_maximumindependentset_to_maximumclique_closed_loop() {
@@ -23,6 +24,43 @@ fn test_maximumindependentset_to_maximumclique_closed_loop() {
         &reduction,
         "MaximumIndependentSet->MaximumClique closed loop",
     );
+}
+
+#[test]
+fn exact_size_map_matches_constructed_complement() {
+    let source = MaximumIndependentSet::new(
+        SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+        vec![1i32; 5],
+    );
+    let size_map = SizeMap::new(
+        "MaximumIndependentSet -> MaximumClique",
+        [
+            ("num_vertices", crate::expr::Expr::parse("num_vertices")),
+            (
+                "num_edges",
+                crate::expr::Expr::parse("num_vertices * (num_vertices - 1) / 2 - num_edges"),
+            ),
+        ],
+    )
+    .unwrap();
+
+    let predicted = size_map
+        .evaluate(&ProblemSize::new(vec![
+            ("num_vertices", source.num_vertices()),
+            ("num_edges", source.num_edges()),
+        ]))
+        .unwrap();
+    let reduction = ReduceTo::<MaximumClique<SimpleGraph, i32>>::reduce_to(&source);
+    let constructed = ProblemSize::new(vec![
+        ("num_vertices", reduction.target_problem().num_vertices()),
+        ("num_edges", reduction.target_problem().num_edges()),
+    ]);
+
+    assert_eq!(
+        predicted,
+        ProblemSize::new(vec![("num_vertices", 5), ("num_edges", 6)])
+    );
+    assert_eq!(predicted, constructed);
 }
 
 #[test]

--- a/src/unit_tests/size_map.rs
+++ b/src/unit_tests/size_map.rs
@@ -1,0 +1,226 @@
+use super::{ExactPlanNode, SizeMap, SizeMapError};
+use crate::expr::Expr;
+use crate::types::ProblemSize;
+use std::sync::Arc;
+
+fn map(expression: &str) -> SizeMap {
+    SizeMap::new(
+        "Source -> Target",
+        [("target_size", Expr::parse(expression))],
+    )
+    .unwrap()
+}
+
+#[test]
+fn evaluates_exact_integer_arithmetic() {
+    let size_map = SizeMap::new(
+        "MaximumIndependentSet -> MaximumClique",
+        [
+            ("num_vertices", Expr::parse("num_vertices")),
+            (
+                "num_edges",
+                Expr::parse("num_vertices * (num_vertices - 1) / 2 - num_edges"),
+            ),
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(
+        size_map
+            .evaluate(&ProblemSize::new(vec![
+                ("num_vertices", 5),
+                ("num_edges", 4),
+            ]))
+            .unwrap(),
+        ProblemSize::new(vec![("num_vertices", 5), ("num_edges", 6)])
+    );
+}
+
+#[test]
+fn composes_by_exact_canonical_substitution() {
+    let first = SizeMap::new(
+        "A -> B",
+        [
+            ("vertices", Expr::parse("n + 1")),
+            ("edges", Expr::parse("m * 2")),
+        ],
+    )
+    .unwrap();
+    let second = SizeMap::new("B -> C", [("size", Expr::parse("vertices * edges / 2"))]).unwrap();
+
+    let composed = first.compose(&second, "A -> B -> C").unwrap();
+    assert_eq!(
+        composed
+            .evaluate(&ProblemSize::new(vec![("n", 4), ("m", 3)]))
+            .unwrap(),
+        ProblemSize::new(vec![("size", 15)])
+    );
+    assert_eq!(
+        composed.get("size"),
+        Some(&Expr::parse("2 * m * (n + 1) / 2"))
+    );
+}
+
+#[test]
+fn composition_reports_every_missing_intermediate_field() {
+    let first = SizeMap::new("A -> B", [("x", Expr::parse("n"))]).unwrap();
+    let second = SizeMap::new("B -> C", [("z", Expr::parse("x + y + z"))]).unwrap();
+
+    assert_eq!(
+        first.compose(&second, "A -> B -> C").unwrap_err(),
+        SizeMapError::MissingCompositionInput {
+            edge: "A -> B -> C".into(),
+            target_field: "z".into(),
+            input_fields: vec!["y".into(), "z".into()],
+        }
+    );
+}
+
+#[test]
+fn rejects_missing_input_field() {
+    assert_eq!(
+        map("n + m")
+            .evaluate(&ProblemSize::new(vec![("n", 2)]))
+            .unwrap_err(),
+        SizeMapError::MissingInputField {
+            edge: "Source -> Target".into(),
+            target_field: "target_size".into(),
+            input_field: "m".into(),
+        }
+    );
+}
+
+#[test]
+fn rejects_negative_output() {
+    assert!(matches!(
+        map("n - 3")
+            .evaluate(&ProblemSize::new(vec![("n", 2)]))
+            .unwrap_err(),
+        SizeMapError::NegativeResult { .. }
+    ));
+}
+
+#[test]
+fn rejects_non_integral_output() {
+    assert!(matches!(
+        map("n / 2")
+            .evaluate(&ProblemSize::new(vec![("n", 3)]))
+            .unwrap_err(),
+        SizeMapError::NonIntegralResult { .. }
+    ));
+}
+
+#[test]
+fn rejects_division_by_zero() {
+    assert!(matches!(
+        map("n / m")
+            .evaluate(&ProblemSize::new(vec![("n", 3), ("m", 0)]))
+            .unwrap_err(),
+        SizeMapError::DivisionByZero { .. }
+    ));
+}
+
+#[test]
+fn rejects_concrete_output_overflow_after_arbitrary_precision_evaluation() {
+    assert!(matches!(
+        map("n ^ 2")
+            .evaluate(&ProblemSize::new(vec![("n", usize::MAX)]))
+            .unwrap_err(),
+        SizeMapError::OutputOutOfRange { .. }
+    ));
+}
+
+#[test]
+fn rejects_non_integer_fragment_before_evaluation() {
+    assert!(matches!(
+        SizeMap::new("A -> B", [("n", Expr::parse("2.5 * n"))]).unwrap_err(),
+        SizeMapError::NonIntegralConstant { .. }
+    ));
+    assert!(matches!(
+        SizeMap::new("A -> B", [("n", Expr::parse("n ^ 0.5"))]).unwrap_err(),
+        SizeMapError::NonIntegralConstantExponent { .. }
+    ));
+    assert!(matches!(
+        SizeMap::new("A -> B", [("n", Expr::parse("n ^ m"))]).unwrap_err(),
+        SizeMapError::NonIntegralConstantExponent { .. }
+    ));
+    assert!(matches!(
+        SizeMap::new("A -> B", [("n", Expr::parse("exp(n)"))]).unwrap_err(),
+        SizeMapError::UnsupportedOperator {
+            operator: "exp",
+            ..
+        }
+    ));
+    assert!(matches!(
+        SizeMap::new("A -> B", [("n", Expr::parse("log(n)"))]).unwrap_err(),
+        SizeMapError::UnsupportedOperator {
+            operator: "log",
+            ..
+        }
+    ));
+    assert!(matches!(
+        SizeMap::new("A -> B", [("n", Expr::parse("factorial(n)"))]).unwrap_err(),
+        SizeMapError::UnsupportedOperator {
+            operator: "factorial",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn checks_a_root_reciprocal_as_exact_division() {
+    assert!(matches!(
+        map("2 ^ -1").evaluate(&ProblemSize::default()).unwrap_err(),
+        SizeMapError::NonIntegralResult { .. }
+    ));
+}
+
+#[test]
+fn validates_target_field_names_and_uniqueness() {
+    assert!(matches!(
+        SizeMap::new("A -> B", [("not a field", Expr::integer(1))]).unwrap_err(),
+        SizeMapError::InvalidTargetField { .. }
+    ));
+    assert_eq!(
+        SizeMap::new("A -> B", [("n", Expr::integer(1)), ("n", Expr::integer(2))]).unwrap_err(),
+        SizeMapError::DuplicateTargetField {
+            edge: "A -> B".into(),
+            field: "n".into(),
+        }
+    );
+}
+
+#[test]
+fn compiled_batch_preserves_shared_expression_nodes() {
+    let shared = Expr::parse("n * (n + 1)");
+    let size_map = SizeMap::new("A -> B", [("first", shared.clone()), ("second", shared)]).unwrap();
+
+    assert!(Arc::ptr_eq(
+        &size_map.fields[0].plan.0,
+        &size_map.fields[1].plan.0
+    ));
+    assert!(matches!(
+        size_map.fields[0].plan.0.as_ref(),
+        ExactPlanNode::Mul(_)
+    ));
+}
+
+#[test]
+fn long_composition_chain_remains_compact() {
+    let mut composed = SizeMap::new("source -> layer", [("x", Expr::parse("n"))]).unwrap();
+    let increment = SizeMap::new("layer -> layer", [("x", Expr::parse("x + 1"))]).unwrap();
+    for _ in 0..512 {
+        composed = composed
+            .compose(&increment, "source -> layer chain")
+            .unwrap();
+    }
+
+    let expression = composed.get("x").unwrap();
+    assert!(expression.unique_node_count() <= 3);
+    assert_eq!(
+        composed
+            .evaluate(&ProblemSize::new(vec![("n", 7)]))
+            .unwrap(),
+        ProblemSize::new(vec![("x", 519)])
+    );
+}


### PR DESCRIPTION
## Summary
- add a validated target-field to canonical `Expr` SizeMap domain
- compile exact expressions into a private Arc-shared BigInt evaluation plan
- enforce exact division and checked non-negative integral `ProblemSize` conversion with typed edge/field errors
- compose maps by exact DAG substitution without Growth or f64 evaluation
- verify MIS -> MaximumClique predicts and constructs `(5, 6)`
- add shared-batch and 512-layer structural performance regressions

## Verification
- `cargo test size_map --lib`
- `make check`
- focused llvm-cov: `src/size_map.rs` 96.63% line / 95.38% region coverage

Stack layer 1 for #1126. This PR intentionally leaves registry replacement and migration to later stacked layers.