### PR TITLE
Add certified monotone SizeBound contracts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod io;
 pub mod models;
 pub mod registry;
 pub mod rules;
+pub mod size_bound;
 pub mod size_map;
 pub mod solvers;
 pub mod topology;

--- a/src/size_bound.rs
+++ b/src/size_bound.rs
@@ -1,0 +1,410 @@
+//! Certified monotone bounds between problem-size vectors.
+
+use crate::expr::{Expr, ExprNode, ExprNodeId, Symbol};
+use crate::growth::Growth;
+use num_bigint::{BigUint, Sign};
+use num_traits::{One, Zero};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+/// An ordered vector of arbitrary-precision non-negative problem-size bounds.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BoundVector {
+    components: Vec<(Box<str>, BigUint)>,
+}
+
+impl BoundVector {
+    pub fn new<I, N, V>(components: I) -> Self
+    where
+        I: IntoIterator<Item = (N, V)>,
+        N: Into<Box<str>>,
+        V: Into<BigUint>,
+    {
+        Self {
+            components: components
+                .into_iter()
+                .map(|(name, value)| (name.into(), value.into()))
+                .collect(),
+        }
+    }
+
+    pub fn get(&self, name: &str) -> Option<&BigUint> {
+        self.components
+            .iter()
+            .find(|(field, _)| field.as_ref() == name)
+            .map(|(_, value)| value)
+    }
+
+    pub fn components(&self) -> impl Iterator<Item = (&str, &BigUint)> {
+        self.components
+            .iter()
+            .map(|(name, value)| (name.as_ref(), value))
+    }
+}
+
+/// A validated mapping whose expressions are proven non-negative and monotone.
+#[derive(Clone, Debug)]
+pub struct SizeBound {
+    edge: Box<str>,
+    fields: Vec<SizeBoundField>,
+}
+
+#[derive(Clone, Debug)]
+struct SizeBoundField {
+    name: Box<str>,
+    expression: Expr,
+    plan: BoundPlan,
+}
+
+#[derive(Clone, Debug)]
+struct BoundPlan(Arc<BoundPlanNode>);
+
+#[derive(Debug)]
+enum BoundPlanNode {
+    Const(BigUint),
+    Var(Symbol),
+    Add(Box<[BoundPlan]>),
+    Mul(Box<[BoundPlan]>),
+    Pow(BoundPlan, BigUint),
+}
+
+impl BoundPlan {
+    fn identity(&self) -> usize {
+        Arc::as_ptr(&self.0) as usize
+    }
+}
+
+impl SizeBound {
+    /// Prove every expression non-negative and monotone, then compile it.
+    pub fn new<I, N>(edge: impl Into<Box<str>>, fields: I) -> Result<Self, SizeBoundError>
+    where
+        I: IntoIterator<Item = (N, Expr)>,
+        N: Into<Box<str>>,
+    {
+        let edge = edge.into();
+        let mut names = HashSet::new();
+        let mut plans = HashMap::new();
+        let mut compiled_fields = Vec::new();
+        for (name, expression) in fields {
+            let name = name.into();
+            if let Err(error) = Symbol::new(name.clone()) {
+                return Err(SizeBoundError::InvalidTargetField {
+                    edge,
+                    field: name,
+                    reason: error.to_string().into(),
+                });
+            }
+            if !names.insert(name.clone()) {
+                return Err(SizeBoundError::DuplicateTargetField { edge, field: name });
+            }
+            let plan = compile_expression(&expression, &mut plans).map_err(|failure| {
+                validation_error(edge.clone(), name.clone(), expression.to_string(), failure)
+            })?;
+            compiled_fields.push(SizeBoundField {
+                name,
+                expression,
+                plan,
+            });
+        }
+        Ok(Self {
+            edge,
+            fields: compiled_fields,
+        })
+    }
+
+    pub fn edge(&self) -> &str {
+        &self.edge
+    }
+
+    pub fn expressions(&self) -> impl Iterator<Item = (&str, &Expr)> {
+        self.fields
+            .iter()
+            .map(|field| (field.name.as_ref(), &field.expression))
+    }
+
+    pub fn get(&self, target_field: &str) -> Option<&Expr> {
+        self.fields
+            .iter()
+            .find(|field| field.name.as_ref() == target_field)
+            .map(|field| &field.expression)
+    }
+
+    /// Evaluate a certified bound without narrowing to a concrete machine type.
+    pub fn evaluate(&self, input: &BoundVector) -> Result<BoundVector, SizeBoundError> {
+        let mut memo = HashMap::new();
+        let mut output = Vec::with_capacity(self.fields.len());
+        for field in &self.fields {
+            let value = evaluate_plan(&field.plan, input, &mut memo).map_err(|input_field| {
+                SizeBoundError::MissingInputField {
+                    edge: self.edge.clone(),
+                    target_field: field.name.clone(),
+                    input_field,
+                }
+            })?;
+            output.push((field.name.clone(), value));
+        }
+        Ok(BoundVector { components: output })
+    }
+
+    /// Compose two certified bounds and re-prove the substituted expressions.
+    pub fn compose(
+        &self,
+        next: &SizeBound,
+        composed_edge: impl Into<Box<str>>,
+    ) -> Result<SizeBound, SizeBoundError> {
+        let composed_edge = composed_edge.into();
+        let replacements: HashMap<&str, &Expr> = self.expressions().collect();
+        let mut fields = Vec::with_capacity(next.fields.len());
+        for field in &next.fields {
+            let expression = field
+                .expression
+                .substitute_complete(&replacements)
+                .map_err(|error| SizeBoundError::MissingCompositionInput {
+                    edge: composed_edge.clone(),
+                    target_field: field.name.clone(),
+                    input_fields: error.missing_variables().map(Box::<str>::from).collect(),
+                })?;
+            fields.push((field.name.clone(), expression));
+        }
+        Self::new(composed_edge, fields)
+    }
+
+    /// Explicitly project terminal bound expressions into the Growth domain.
+    pub fn project_growth(&self) -> Vec<(Box<str>, Growth)> {
+        let expressions: Vec<_> = self.fields.iter().map(|field| &field.expression).collect();
+        let growth = Growth::from_expr_batch(&expressions);
+        self.fields
+            .iter()
+            .zip(growth)
+            .map(|(field, growth)| (field.name.clone(), growth))
+            .collect()
+    }
+}
+
+fn compile_expression(
+    expression: &Expr,
+    memo: &mut HashMap<ExprNodeId, BoundPlan>,
+) -> Result<BoundPlan, ValidationFailure> {
+    if let Some(plan) = memo.get(&expression.node_identity()) {
+        return Ok(plan.clone());
+    }
+    let node = match expression.node() {
+        ExprNode::Const(value) => {
+            if !value.is_integer() {
+                return Err(ValidationFailure::NonIntegralConstant(
+                    value.to_string().into(),
+                ));
+            }
+            let value = value.to_integer();
+            if value.sign() == Sign::Minus {
+                return Err(ValidationFailure::NegativeCoefficient(value));
+            }
+            BoundPlanNode::Const(value.magnitude().clone())
+        }
+        ExprNode::Var(symbol) => BoundPlanNode::Var(symbol.clone()),
+        ExprNode::Add(values) => BoundPlanNode::Add(
+            values
+                .iter()
+                .map(|value| compile_expression(value, memo))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        ),
+        ExprNode::Mul(values) => BoundPlanNode::Mul(
+            values
+                .iter()
+                .map(|value| compile_expression(value, memo))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        ),
+        ExprNode::Pow(base, exponent) => {
+            let ExprNode::Const(exponent) = exponent.node() else {
+                return Err(ValidationFailure::NonIntegralConstantExponent(
+                    exponent.to_string().into(),
+                ));
+            };
+            if !exponent.is_integer() {
+                return Err(ValidationFailure::NonIntegralConstantExponent(
+                    exponent.to_string().into(),
+                ));
+            }
+            let exponent = exponent.to_integer();
+            if exponent.sign() == Sign::Minus {
+                return Err(ValidationFailure::NegativePower(exponent));
+            }
+            BoundPlanNode::Pow(
+                compile_expression(base, memo)?,
+                exponent.magnitude().clone(),
+            )
+        }
+        ExprNode::Exp(_) => return Err(ValidationFailure::UnsupportedOperator("exp")),
+        ExprNode::Log(_) => return Err(ValidationFailure::UnsupportedOperator("log")),
+        ExprNode::Factorial(_) => return Err(ValidationFailure::UnsupportedOperator("factorial")),
+    };
+    let plan = BoundPlan(Arc::new(node));
+    memo.insert(expression.node_identity(), plan.clone());
+    Ok(plan)
+}
+
+fn evaluate_plan(
+    plan: &BoundPlan,
+    input: &BoundVector,
+    memo: &mut HashMap<usize, BigUint>,
+) -> Result<BigUint, Box<str>> {
+    if let Some(value) = memo.get(&plan.identity()) {
+        return Ok(value.clone());
+    }
+    let value = match plan.0.as_ref() {
+        BoundPlanNode::Const(value) => value.clone(),
+        BoundPlanNode::Var(symbol) => input
+            .get(symbol.as_str())
+            .cloned()
+            .ok_or_else(|| Box::<str>::from(symbol.as_str()))?,
+        BoundPlanNode::Add(values) => values
+            .iter()
+            .try_fold(BigUint::zero(), |sum, value| -> Result<_, Box<str>> {
+                Ok(sum + evaluate_plan(value, input, memo)?)
+            })?,
+        BoundPlanNode::Mul(values) => {
+            values
+                .iter()
+                .try_fold(BigUint::one(), |product, value| -> Result<_, Box<str>> {
+                    Ok(product * evaluate_plan(value, input, memo)?)
+                })?
+        }
+        BoundPlanNode::Pow(base, exponent) => {
+            pow_biguint(evaluate_plan(base, input, memo)?, exponent)
+        }
+    };
+    memo.insert(plan.identity(), value.clone());
+    Ok(value)
+}
+
+fn pow_biguint(mut base: BigUint, exponent: &BigUint) -> BigUint {
+    let mut exponent = exponent.clone();
+    let mut result = BigUint::one();
+    while !exponent.is_zero() {
+        if exponent.bit(0) {
+            result *= &base;
+        }
+        exponent >>= 1usize;
+        if !exponent.is_zero() {
+            base = &base * &base;
+        }
+    }
+    result
+}
+
+#[derive(Debug)]
+enum ValidationFailure {
+    NegativeCoefficient(num_bigint::BigInt),
+    NonIntegralConstant(Box<str>),
+    NegativePower(num_bigint::BigInt),
+    NonIntegralConstantExponent(Box<str>),
+    UnsupportedOperator(&'static str),
+}
+
+fn validation_error(
+    edge: Box<str>,
+    target_field: Box<str>,
+    expression: String,
+    failure: ValidationFailure,
+) -> SizeBoundError {
+    match failure {
+        ValidationFailure::NegativeCoefficient(value) => SizeBoundError::NegativeCoefficient {
+            edge,
+            target_field,
+            expression: expression.into(),
+            value,
+        },
+        ValidationFailure::NonIntegralConstant(value) => SizeBoundError::NonIntegralConstant {
+            edge,
+            target_field,
+            expression: expression.into(),
+            value,
+        },
+        ValidationFailure::NegativePower(exponent) => SizeBoundError::NegativePower {
+            edge,
+            target_field,
+            expression: expression.into(),
+            exponent,
+        },
+        ValidationFailure::NonIntegralConstantExponent(exponent) => {
+            SizeBoundError::NonIntegralConstantExponent {
+                edge,
+                target_field,
+                expression: expression.into(),
+                exponent,
+            }
+        }
+        ValidationFailure::UnsupportedOperator(operator) => SizeBoundError::UnsupportedOperator {
+            edge,
+            target_field,
+            expression: expression.into(),
+            operator,
+        },
+    }
+}
+
+/// Validation, composition, or evaluation failure for a [`SizeBound`].
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum SizeBoundError {
+    #[error("size bound for edge {edge} has invalid target field {field:?}: {reason}")]
+    InvalidTargetField {
+        edge: Box<str>,
+        field: Box<str>,
+        reason: Box<str>,
+    },
+    #[error("size bound for edge {edge} declares target field {field} more than once")]
+    DuplicateTargetField { edge: Box<str>, field: Box<str> },
+    #[error("size bound for edge {edge}, target field {target_field}, contains negative coefficient {value} in {expression}")]
+    NegativeCoefficient {
+        edge: Box<str>,
+        target_field: Box<str>,
+        expression: Box<str>,
+        value: num_bigint::BigInt,
+    },
+    #[error("size bound for edge {edge}, target field {target_field}, contains non-integral constant {value} in {expression}")]
+    NonIntegralConstant {
+        edge: Box<str>,
+        target_field: Box<str>,
+        expression: Box<str>,
+        value: Box<str>,
+    },
+    #[error("size bound for edge {edge}, target field {target_field}, contains negative power {exponent} in {expression}")]
+    NegativePower {
+        edge: Box<str>,
+        target_field: Box<str>,
+        expression: Box<str>,
+        exponent: num_bigint::BigInt,
+    },
+    #[error("size bound for edge {edge}, target field {target_field}, requires a constant integral exponent, found {exponent} in {expression}")]
+    NonIntegralConstantExponent {
+        edge: Box<str>,
+        target_field: Box<str>,
+        expression: Box<str>,
+        exponent: Box<str>,
+    },
+    #[error("size bound for edge {edge}, target field {target_field}, does not support {operator} in {expression}")]
+    UnsupportedOperator {
+        edge: Box<str>,
+        target_field: Box<str>,
+        expression: Box<str>,
+        operator: &'static str,
+    },
+    #[error("size bound composition for edge {edge}, target field {target_field}, is missing intermediate fields {input_fields:?}")]
+    MissingCompositionInput {
+        edge: Box<str>,
+        target_field: Box<str>,
+        input_fields: Vec<Box<str>>,
+    },
+    #[error("size bound for edge {edge}, target field {target_field}, is missing input field {input_field}")]
+    MissingInputField {
+        edge: Box<str>,
+        target_field: Box<str>,
+        input_field: Box<str>,
+    },
+}
+
+#[cfg(test)]
+#[path = "unit_tests/size_bound.rs"]
+mod tests;

--- a/src/size_map.rs
+++ b/src/size_map.rs
@@ -1,6 +1,7 @@
 //! Exact symbolic maps between problem-size vectors.
 
 use crate::expr::{Expr, ExprNode, ExprNodeId, Symbol};
+use crate::growth::Growth;
 use crate::types::ProblemSize;
 use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::{One, Signed, Zero};
@@ -163,6 +164,17 @@ impl SizeMap {
             fields.push((field.name.clone(), expression));
         }
         Self::new(composed_edge, fields)
+    }
+
+    /// Explicitly project terminal exact expressions into the Growth domain.
+    pub fn project_growth(&self) -> Vec<(Box<str>, Growth)> {
+        let expressions: Vec<_> = self.fields.iter().map(|field| &field.expression).collect();
+        let growth = Growth::from_expr_batch(&expressions);
+        self.fields
+            .iter()
+            .zip(growth)
+            .map(|(field, growth)| (field.name.clone(), growth))
+            .collect()
     }
 }
 

--- a/src/unit_tests/rules/maximumindependentset_maximumclique.rs
+++ b/src/unit_tests/rules/maximumindependentset_maximumclique.rs
@@ -1,9 +1,11 @@
 use super::*;
 use crate::rules::test_helpers::assert_optimization_round_trip_from_optimization_target;
+use crate::size_bound::{BoundVector, SizeBound};
 use crate::size_map::SizeMap;
 use crate::solvers::BruteForce;
 use crate::traits::Problem;
 use crate::types::{One, ProblemSize};
+use num_bigint::BigUint;
 
 #[test]
 fn test_maximumindependentset_to_maximumclique_closed_loop() {
@@ -61,6 +63,41 @@ fn exact_size_map_matches_constructed_complement() {
         ProblemSize::new(vec![("num_vertices", 5), ("num_edges", 6)])
     );
     assert_eq!(predicted, constructed);
+}
+
+#[test]
+fn certified_size_bound_contains_constructed_complement() {
+    let source = MaximumIndependentSet::new(
+        SimpleGraph::new(5, vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+        vec![1i32; 5],
+    );
+    let size_bound = SizeBound::new(
+        "MaximumIndependentSet -> MaximumClique",
+        [
+            ("num_vertices", crate::expr::Expr::parse("num_vertices")),
+            ("num_edges", crate::expr::Expr::parse("num_vertices ^ 2")),
+        ],
+    )
+    .unwrap();
+
+    let predicted = size_bound
+        .evaluate(&BoundVector::new([
+            ("num_vertices", source.num_vertices()),
+            ("num_edges", source.num_edges()),
+        ]))
+        .unwrap();
+    let reduction = ReduceTo::<MaximumClique<SimpleGraph, i32>>::reduce_to(&source);
+
+    assert_eq!(predicted.get("num_vertices"), Some(&BigUint::from(5u8)));
+    assert_eq!(predicted.get("num_edges"), Some(&BigUint::from(25u8)));
+    assert!(
+        BigUint::from(reduction.target_problem().num_vertices())
+            <= *predicted.get("num_vertices").unwrap()
+    );
+    assert!(
+        BigUint::from(reduction.target_problem().num_edges())
+            <= *predicted.get("num_edges").unwrap()
+    );
 }
 
 #[test]

--- a/src/unit_tests/size_bound.rs
+++ b/src/unit_tests/size_bound.rs
@@ -1,0 +1,192 @@
+use super::{BoundPlanNode, BoundVector, SizeBound, SizeBoundError};
+use crate::expr::Expr;
+use crate::growth::Growth;
+use num_bigint::BigUint;
+use num_traits::One;
+use std::sync::Arc;
+
+#[test]
+fn evaluates_arbitrary_precision_monotone_bounds() {
+    let bound = SizeBound::new(
+        "A -> B",
+        [
+            ("vertices", Expr::parse("n")),
+            ("encoding", Expr::parse("n ^ 2 + n * bits")),
+        ],
+    )
+    .unwrap();
+    let n = BigUint::one() << 100usize;
+
+    let result = bound
+        .evaluate(&BoundVector::new([
+            ("n", n.clone()),
+            ("bits", BigUint::from(7u8)),
+        ]))
+        .unwrap();
+
+    assert_eq!(result.get("vertices"), Some(&n));
+    assert_eq!(
+        result.get("encoding"),
+        Some(&(&n * &n + &n * BigUint::from(7u8)))
+    );
+}
+
+#[test]
+fn accepts_canonical_zero_after_subtraction_eliminates_itself() {
+    let bound = SizeBound::new("A -> B", [("size", Expr::parse("n - n"))]).unwrap();
+
+    assert_eq!(
+        bound.evaluate(&BoundVector::new([("n", 42u8)])).unwrap(),
+        BoundVector::new([("size", 0u8)])
+    );
+}
+
+#[test]
+fn rejects_irreducible_negative_coefficients_and_powers() {
+    assert!(matches!(
+        SizeBound::new("A -> B", [("size", Expr::parse("n - m"))]).unwrap_err(),
+        SizeBoundError::NegativeCoefficient { .. }
+    ));
+    assert!(matches!(
+        SizeBound::new("A -> B", [("size", Expr::parse("n / m"))]).unwrap_err(),
+        SizeBoundError::NegativePower { .. }
+    ));
+}
+
+#[test]
+fn rejects_constants_and_powers_outside_the_bound_fragment() {
+    assert!(matches!(
+        SizeBound::new("A -> B", [("size", Expr::parse("0.5 * n"))]).unwrap_err(),
+        SizeBoundError::NonIntegralConstant { .. }
+    ));
+    assert!(matches!(
+        SizeBound::new("A -> B", [("size", Expr::parse("n ^ 0.5"))]).unwrap_err(),
+        SizeBoundError::NonIntegralConstantExponent { .. }
+    ));
+    assert!(matches!(
+        SizeBound::new("A -> B", [("size", Expr::parse("n ^ m"))]).unwrap_err(),
+        SizeBoundError::NonIntegralConstantExponent { .. }
+    ));
+}
+
+#[test]
+fn rejects_functions_without_structural_monotonicity_rules() {
+    for (expression, operator) in [
+        ("exp(n)", "exp"),
+        ("log(n)", "log"),
+        ("factorial(n)", "factorial"),
+    ] {
+        assert!(matches!(
+            SizeBound::new("A -> B", [("size", Expr::parse(expression))]).unwrap_err(),
+            SizeBoundError::UnsupportedOperator {
+                operator: actual,
+                ..
+            } if actual == operator
+        ));
+    }
+}
+
+#[test]
+fn reports_missing_input_field() {
+    let bound = SizeBound::new("A -> B", [("size", Expr::parse("n + m"))]).unwrap();
+
+    assert_eq!(
+        bound.evaluate(&BoundVector::new([("n", 3u8)])).unwrap_err(),
+        SizeBoundError::MissingInputField {
+            edge: "A -> B".into(),
+            target_field: "size".into(),
+            input_field: "m".into(),
+        }
+    );
+}
+
+#[test]
+fn composes_certified_bounds_by_canonical_substitution() {
+    let first = SizeBound::new(
+        "A -> B",
+        [
+            ("vertices", Expr::parse("n + 1")),
+            ("edges", Expr::parse("n ^ 2")),
+        ],
+    )
+    .unwrap();
+    let second = SizeBound::new("B -> C", [("encoding", Expr::parse("vertices * edges"))]).unwrap();
+
+    let composed = first.compose(&second, "A -> B -> C").unwrap();
+    assert_eq!(
+        composed.evaluate(&BoundVector::new([("n", 4u8)])).unwrap(),
+        BoundVector::new([("encoding", 80u8)])
+    );
+}
+
+#[test]
+fn composition_reports_all_missing_intermediate_fields() {
+    let first = SizeBound::new("A -> B", [("x", Expr::parse("n"))]).unwrap();
+    let second = SizeBound::new("B -> C", [("z", Expr::parse("x + y + z"))]).unwrap();
+
+    assert_eq!(
+        first.compose(&second, "A -> B -> C").unwrap_err(),
+        SizeBoundError::MissingCompositionInput {
+            edge: "A -> B -> C".into(),
+            target_field: "z".into(),
+            input_fields: vec!["y".into(), "z".into()],
+        }
+    );
+}
+
+#[test]
+fn growth_projection_is_explicit_and_terminal() {
+    let bound = SizeBound::new("A -> B", [("edges", Expr::parse("n ^ 2"))]).unwrap();
+
+    assert_eq!(
+        bound.project_growth(),
+        vec![("edges".into(), Growth::from_expr(&Expr::parse("n ^ 2")))]
+    );
+}
+
+#[test]
+fn validates_target_fields() {
+    assert!(matches!(
+        SizeBound::new("A -> B", [("not a field", Expr::integer(1))]).unwrap_err(),
+        SizeBoundError::InvalidTargetField { .. }
+    ));
+    assert_eq!(
+        SizeBound::new("A -> B", [("n", Expr::integer(1)), ("n", Expr::integer(2))]).unwrap_err(),
+        SizeBoundError::DuplicateTargetField {
+            edge: "A -> B".into(),
+            field: "n".into(),
+        }
+    );
+}
+
+#[test]
+fn compiled_batch_preserves_shared_expression_nodes() {
+    let shared = Expr::parse("n * (n + 1)");
+    let bound = SizeBound::new("A -> B", [("first", shared.clone()), ("second", shared)]).unwrap();
+
+    assert!(Arc::ptr_eq(
+        &bound.fields[0].plan.0,
+        &bound.fields[1].plan.0
+    ));
+    assert!(matches!(
+        bound.fields[0].plan.0.as_ref(),
+        BoundPlanNode::Mul(_)
+    ));
+}
+
+#[test]
+fn long_composition_chain_remains_compact() {
+    let mut composed = SizeBound::new("source -> layer", [("x", Expr::parse("n"))]).unwrap();
+    let increment = SizeBound::new("layer -> layer", [("x", Expr::parse("x + 1"))]).unwrap();
+    for _ in 0..512 {
+        composed = composed
+            .compose(&increment, "source -> layer chain")
+            .unwrap();
+    }
+
+    assert!(composed.get("x").unwrap().unique_node_count() <= 3);
+    assert_eq!(
+        composed.evaluate(&BoundVector::new([("n", 7u8)])).unwrap(),
+        BoundVector::new([("x", 519u16)])
+    );
+}

--- a/src/unit_tests/size_map.rs
+++ b/src/unit_tests/size_map.rs
@@ -1,5 +1,6 @@
 use super::{ExactPlanNode, SizeMap, SizeMapError};
 use crate::expr::Expr;
+use crate::growth::Growth;
 use crate::types::ProblemSize;
 use std::sync::Arc;
 
@@ -173,6 +174,16 @@ fn checks_a_root_reciprocal_as_exact_division() {
         map("2 ^ -1").evaluate(&ProblemSize::default()).unwrap_err(),
         SizeMapError::NonIntegralResult { .. }
     ));
+}
+
+#[test]
+fn growth_projection_is_explicit_and_terminal() {
+    let size_map = SizeMap::new("A -> B", [("size", Expr::parse("n ^ 2 + n"))]).unwrap();
+
+    assert_eq!(
+        size_map.project_growth(),
+        vec![("size".into(), Growth::from_expr(&Expr::parse("n ^ 2 + n")))]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add arbitrary-precision `BoundVector` values backed by `BigUint`
- validate canonical expressions with a deliberately small structural monotonicity proof
- reject irreducible negative coefficients, negative powers, fractional constants/powers, and unsupported functions
- compose certified bounds by exact DAG substitution and revalidation
- expose explicit terminal-only Growth projection for both SizeBound and SizeMap
- verify the MIS -> MaximumClique construction satisfies the `(n, n^2)` certified bound
- add shared-batch and 512-layer structural performance regressions

## Verification
- `cargo test size_bound --lib`
- `cargo test size_map --lib`
- `make check`
- focused llvm-cov: `src/size_bound.rs` 95.54% line / 95.38% region coverage

Stack layer 2 for #1126. Base: #1128. Registry replacement and repository migration remain in later stack layers.